### PR TITLE
feat: add subscription menu entry to user menu

### DIFF
--- a/src/components/UserMenu.jsx
+++ b/src/components/UserMenu.jsx
@@ -328,6 +328,19 @@ export function UserMenu({ condensed = false }) {
                     <Gear className="w-4 h-4" aria-hidden="true" />
                     Account & Settings
                   </Link>
+                  <Link
+                    to={isPaid ? '/account#subscription' : '/pricing'}
+                    onClick={closeDropdown}
+                    className="
+                      w-full text-left px-4 py-3 min-h-[44px]
+                      text-sm text-accent hover:bg-accent/5 active:bg-accent/10
+                      flex items-center gap-2 touch-manipulation
+                      focus-visible:outline-none focus-visible:bg-accent/5
+                      border-b border-accent/10
+                    "
+                  >
+                    {isPaid ? 'Manage Subscription' : 'View Plans'}
+                  </Link>
 
                   {/* Replay Tutorial */}
                   <button


### PR DESCRIPTION
### Motivation
- Add an explicit subscription-related menu item beneath the existing "Account & Settings" entry so paid users can manage their subscription and free users can view plans.

### Description
- Inserted a conditional `Link` directly under the Account entry that uses `isPaid ? '/account#subscription' : '/pricing'` and displays `Manage Subscription` for paid users or `View Plans` for free users, reusing the existing menu item classes and `min-h-[44px]` touch target and calling `closeDropdown` on click.

### Testing
- Started the frontend dev server with `npm run dev:frontend`, which came up successfully; no unit or E2E test suite was executed.
- Attempted a Playwright screenshot to validate the menu visually, but the Chromium run crashed in this environment (Playwright failed with a browser crash), so the visual test did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749c274fd48328b1f8e25e4bf42c5c)

## Summary by Sourcery

New Features:
- Expose a conditional user menu item that routes paid users to subscription management and free users to the pricing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new navigation option in the user menu that links to subscription management for existing subscribers or pricing plans for non-subscribers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->