### PR TITLE
feat(account): warn about active subscriptions before account deletion

### DIFF
--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -2118,18 +2118,30 @@ export default function AccountPage() {
                 </button>
                 <div className="flex-1 space-y-2">
                   {hasActiveSubscription && (
-                    <div className="rounded-xl border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
-                      <p>
-                        Active subscription detected.{' '}
+                    <div
+                      className="rounded-xl border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs"
+                      role="status"
+                      aria-live="polite"
+                      aria-atomic="true"
+                    >
+                      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                        <p className="text-amber-200">
+                          Active subscription detected. Manage your subscription first to avoid future charges.
+                        </p>
                         <button
                           type="button"
                           onClick={handleManageSubscription}
-                          className="font-semibold underline underline-offset-2 transition hover:text-warning/80"
+                          disabled={portalLoading}
+                          className={`inline-flex items-center gap-1 font-semibold underline underline-offset-2 transition hover:text-amber-100 text-amber-100 ${
+                            portalLoading ? 'opacity-60 cursor-not-allowed' : ''
+                          }`}
                         >
+                          {portalLoading && (
+                            <CircleNotch className="h-3 w-3 animate-spin" weight="bold" />
+                          )}
                           Manage subscription
-                        </button>{' '}
-                        first to avoid future charges.
-                      </p>
+                        </button>
+                      </div>
                     </div>
                   )}
                   <button

--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -2116,18 +2116,34 @@ export default function AccountPage() {
                   <DownloadSimple className="h-4 w-4" />
                   Download account data
                 </button>
-                <button
-                  type="button"
-                  onClick={() => setDeleteModalOpen(true)}
-                  className="
-                    flex-1 inline-flex items-center justify-center gap-2 rounded-full
-                    border border-error/40 bg-error/10 px-4 py-2.5 text-xs font-semibold text-error
-                    hover:bg-error/20 transition
-                  "
-                >
-                  <Trash className="h-4 w-4" />
-                  Delete account
-                </button>
+                <div className="flex-1 space-y-2">
+                  {hasActiveSubscription && (
+                    <div className="rounded-xl border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+                      <p>
+                        Active subscription detected.{' '}
+                        <button
+                          type="button"
+                          onClick={handleManageSubscription}
+                          className="font-semibold underline underline-offset-2 transition hover:text-warning/80"
+                        >
+                          Manage subscription first to avoid future charges.
+                        </button>
+                      </p>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setDeleteModalOpen(true)}
+                    className="
+                      w-full inline-flex items-center justify-center gap-2 rounded-full
+                      border border-error/40 bg-error/10 px-4 py-2.5 text-xs font-semibold text-error
+                      hover:bg-error/20 transition
+                    "
+                  >
+                    <Trash className="h-4 w-4" />
+                    Delete account
+                  </button>
+                </div>
               </div>
               <p className="text-xs text-muted mt-2">
                 Deleting your account removes your synced journal, analytics, and memories. This cannot be undone.

--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -2126,8 +2126,9 @@ export default function AccountPage() {
                           onClick={handleManageSubscription}
                           className="font-semibold underline underline-offset-2 transition hover:text-warning/80"
                         >
-                          Manage subscription first to avoid future charges.
-                        </button>
+                          Manage subscription
+                        </button>{' '}
+                        first to avoid future charges.
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
### Motivation
- Prevent users from accidentally deleting accounts while an active subscription may still bill them by surfacing a pre-delete warning and a path to manage billing.

### Description
- Added a visible inline callout above the Delete account button in the "Account data" block that renders when `hasActiveSubscription` is true and contains a contextual action that calls `handleManageSubscription`.
- Kept the existing delete confirmation modal and copy unchanged and moved the pre-delete warning to always be visible when a subscription is active.
- Changed markup in `src/pages/AccountPage.jsx` to wrap the delete button and optional warning in a `flex-1` container and style the callout using existing utility classes.

### Testing
- Started the frontend dev server with `npm run dev:frontend` which reported Vite ready and network URL as expected.
- Ran a Playwright script that navigated to `/account` and produced a screenshot at `artifacts/account-page.png`, confirming the UI change was rendered; the screenshot artifact was created successfully despite unrelated dev proxy errors in the logs.
- No unit or e2e test suites were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749c198cd08328a58f65bcf5b096e4)

## Summary by Sourcery

New Features:
- Display a pre-delete warning callout when an account with an active subscription is viewed, guiding users to manage billing before deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning banner on the Account page that alerts users with active subscriptions before deleting their account. Users are now prompted to manage their subscription first, improving the account deletion workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->