### PR TITLE
feat(subscription): show billing interval and renewal date on Account page

### DIFF
--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -984,10 +984,7 @@ export default function AccountPage() {
         : `Billed ${normalizedBillingInterval}`)
     : null;
   const periodEndTimestamp = stripeMeta?.currentPeriodEnd || null;
-  const trialEndTimestamp = normalizeTimestamp(
-    subscriptionDetails?.trial_end
-    || stripeMeta?.trialEnd
-  );
+  const trialEndTimestamp = stripeMeta?.trialEnd || null;
   const renewalLabel = statusValue === 'trialing'
     ? (trialEndTimestamp
       ? `Trial ends ${formatDate(trialEndTimestamp)}`

--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -983,11 +983,7 @@ export default function AccountPage() {
         ? 'Billed monthly'
         : `Billed ${normalizedBillingInterval}`)
     : null;
-  const periodEndTimestamp = normalizeTimestamp(
-    subscriptionDetails?.current_period_end
-    || subscriptionDetails?.currentPeriodEnd
-    || stripeMeta?.currentPeriodEnd
-  );
+  const periodEndTimestamp = stripeMeta?.currentPeriodEnd || null;
   const trialEndTimestamp = normalizeTimestamp(
     subscriptionDetails?.trial_end
     || stripeMeta?.trialEnd


### PR DESCRIPTION
### Motivation
- Surface explicit billing microcopy in the Subscription summary so users can see billing interval and next renewal/trial end date. 
- Ensure the UI renders useful data for both active and trialing subscriptions and degrades gracefully if backend fields are missing.

### Description
- Added timestamp normalization and parsing helpers (`normalizeTimestamp`) and reused `formatDate` to handle seconds vs milliseconds inputs in `src/pages/AccountPage.jsx`.
- Derived billing interval from multiple possible fields (`subscriptionDetails.billingInterval`, `subscriptionDetails.plan.interval`, `stripeMeta.plan.interval`, `subscriptionDetails.interval`) and produced a human label (`Billed annually` / `Billed monthly`) with safe fallbacks.
- Normalized period/trial end timestamps from `current_period_end`, `currentPeriodEnd`, `trial_end`, or `trialEnd` and produced a renewal/trial label (`Renews …` / `Trial ends …`).
- Composed a `billingLine` (interval + renewal) and rendered a small `Billing: ...` microcopy line under the price in the Subscription card when appropriate.

### Testing
- Started the frontend dev server with `npm run dev:frontend`, which launched Vite successfully and served the app (server ready on http://localhost:5173). (succeeded)
- Ran a Playwright script to open `/account` and capture a screenshot, which executed and produced a screenshot artifact; however the dev server logged proxy errors for `/api/auth/me` due to a refused backend connection, so some authenticated API calls did not complete. (succeeded partially — UI rendered, API calls failed due to local proxy/backend connectivity)
- No unit tests or CI test suites were executed in this change (`npm test` / e2e suites were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749c0fe6fc8328866eb38158a40f96)

## Summary by Sourcery

Display clearer subscription billing information on the Account page, including interval and renewal/trial end details, with robust handling of varying backend fields and timestamp formats.

New Features:
- Show a billing microcopy line under the subscription price summarizing billing interval and next renewal or trial end date on the Account page.

Enhancements:
- Derive billing interval and renewal/trial dates from multiple possible subscription metadata fields and normalize timestamps to handle both seconds- and milliseconds-based values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced subscription section on the Account page with more detailed billing information, including clearer billing interval labels ("Billed monthly", "Billed annually") and renewal/trial end dates for better transparency on subscription status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->