### PR TITLE
feat: add “View all” patterns snapshot to Reading Journey (sidebar + mobile)

### DIFF
--- a/src/components/ReadingJourney/JourneyMobileSheet.jsx
+++ b/src/components/ReadingJourney/JourneyMobileSheet.jsx
@@ -92,12 +92,24 @@ export default function JourneyMobileSheet({
   const navigate = useNavigate();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('cards');
+  const [showAllPatterns, setShowAllPatterns] = useState(false);
   const sheetRef = useRef(null);
   const closeButtonRef = useRef(null);
   const triggerButtonRef = useRef(null);
   const abortControllerRef = useRef(null);
   const scopeChipLabel = analyticsScope === 'filters' && filtersActive ? 'Filtered' : (scopeLabel || 'Scope');
   const sourceLabel = _dataSource === 'server' ? 'D1' : 'Journal';
+  const timeframeLabel = scopeLabel || (filtersActive && analyticsScope === 'filters' ? 'Filtered view' : 'Current view');
+  const dateFormatOptions = {
+    month: 'long',
+    year: 'numeric',
+    ...((seasonTimezone || timezone) && { timeZone: seasonTimezone || timezone }),
+  };
+  const formattedSeasonWindow = seasonWindow
+    ? `${new Intl.DateTimeFormat(locale, dateFormatOptions).format(seasonWindow.start)} – ${new Intl.DateTimeFormat(locale, dateFormatOptions).format(seasonWindow.end)}`
+    : null;
+  const hasMoreThemes = themes.length > 4;
+  const hasMoreContexts = contextBreakdown.length > 4;
   const streakGraceTooltip = 'Counts from yesterday if no reading today (grace period).';
   const streakInfoButtonClass =
     'text-muted hover:text-main focus-visible:ring-[color:var(--accent-45)] -ml-2 -mr-2';
@@ -214,6 +226,10 @@ export default function JourneyMobileSheet({
     abortControllerRef.current = new AbortController();
     handleBackfill(abortControllerRef.current.signal);
   }, [handleBackfill]);
+
+  const handlePatternsToggle = useCallback(() => {
+    setShowAllPatterns((prev) => !prev);
+  }, []);
 
   // Show loading skeleton
   if (isLoading) {
@@ -585,10 +601,22 @@ export default function JourneyMobileSheet({
               {activeTab === 'patterns' && (
                 <>
                   {contextBreakdown.length > 0 && (
-                    <ContextBreakdown
-                      data={contextBreakdown}
-                      preferenceDrift={preferenceDrift}
-                    />
+                    <div className="space-y-2">
+                      <ContextBreakdown
+                        data={contextBreakdown}
+                        preferenceDrift={preferenceDrift}
+                      />
+                      {hasMoreContexts && (
+                        <button
+                          type="button"
+                          onClick={handlePatternsToggle}
+                          aria-expanded={showAllPatterns}
+                          className="text-xs font-semibold text-[color:var(--text-accent)] hover:text-main focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
+                        >
+                          {showAllPatterns ? 'Hide focus areas' : 'View all focus areas'}
+                        </button>
+                      )}
+                    </div>
                   )}
                   {themes.length > 0 && (
                     <div>
@@ -603,6 +631,61 @@ export default function JourneyMobileSheet({
                           </span>
                         ))}
                       </div>
+                      {hasMoreThemes && (
+                        <button
+                          type="button"
+                          onClick={handlePatternsToggle}
+                          aria-expanded={showAllPatterns}
+                          className="mt-2 text-xs font-semibold text-[color:var(--text-accent)] hover:text-main focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
+                        >
+                          {showAllPatterns ? 'Hide themes' : 'View all themes'}
+                        </button>
+                      )}
+                    </div>
+                  )}
+                  {showAllPatterns && (hasMoreContexts || hasMoreThemes) && (
+                    <div className="rounded-2xl border border-[color:var(--border-warm-light)] bg-[color:var(--border-warm-subtle)] p-4 space-y-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-high">
+                            Full Patterns Snapshot
+                          </p>
+                          <p className="text-[11px] text-muted">
+                            Timeframe: {timeframeLabel}
+                            {formattedSeasonWindow ? ` · ${formattedSeasonWindow}` : ''}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={handlePatternsToggle}
+                          className="flex h-7 w-7 items-center justify-center rounded-full text-muted hover:text-main hover:bg-[color:var(--border-warm-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
+                          aria-label="Close full patterns snapshot"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                      {contextBreakdown.length > 0 && (
+                        <ContextBreakdown
+                          data={contextBreakdown}
+                          preferenceDrift={preferenceDrift}
+                          maxItems={contextBreakdown.length}
+                        />
+                      )}
+                      {themes.length > 0 && (
+                        <div>
+                          <p className="text-xs text-muted mb-2">All Themes</p>
+                          <div className="flex flex-wrap gap-1.5">
+                            {themes.map((theme, i) => (
+                              <span
+                                key={`${theme}-${i}`}
+                                className="rounded-full bg-[color:var(--panel-dark-3)] px-2.5 py-1 text-xs text-muted-high"
+                              >
+                                {theme}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
                   )}
                   {cadence.length > 0 && <CadenceSection data={cadence} />}

--- a/src/components/ReadingJourney/JourneySidebar.jsx
+++ b/src/components/ReadingJourney/JourneySidebar.jsx
@@ -481,8 +481,6 @@ export default function JourneySidebar({
                   onClose={handlePatternsToggle}
                 />
               )}
-                </div>
-              )}
 
               {/* Reading Cadence */}
               {cadence.length > 0 && <CadenceSection data={cadence} variant="sidebar" />}

--- a/src/components/ReadingJourney/JourneySidebar.jsx
+++ b/src/components/ReadingJourney/JourneySidebar.jsx
@@ -16,13 +16,13 @@ import {
   Export,
   Fire,
   Gear,
-  Info,
-  X
+  Info
 } from '@phosphor-icons/react';
 import { Tooltip } from '../Tooltip';
 import SeasonSummary from './sections/SeasonSummary';
 import CardsCallingYou from './sections/CardsCallingYou';
 import ContextBreakdown from './sections/ContextBreakdown';
+import PatternsSnapshotPanel from './sections/PatternsSnapshotPanel';
 import MajorArcanaMap from './sections/MajorArcanaMap';
 import AchievementsRow from './sections/AchievementsRow';
 import CadenceSection from './sections/CadenceSection';
@@ -32,6 +32,7 @@ import JournalSummarySection from './sections/JournalSummarySection';
 import EmptyState from './sections/EmptyState';
 import BackfillBanner from './sections/BackfillBanner';
 import PatternAlertBanner from '../PatternAlertBanner';
+import { usePatternsSnapshot } from './hooks/usePatternsSnapshot';
 
 /**
  * CollapsibleSection - Expandable section wrapper.
@@ -148,19 +149,28 @@ export default function JourneySidebar({
     abortControllerRef.current = new AbortController();
     handleBackfill(abortControllerRef.current.signal);
   }, [handleBackfill]);
+
   const scopeChipLabel = analyticsScope === 'filters' && filtersActive ? 'Filtered' : (scopeLabel || 'Scope');
   const sourceLabel = _dataSource === 'server' ? 'D1' : 'Journal';
-  const timeframeLabel = scopeLabel || (filtersActive && analyticsScope === 'filters' ? 'Filtered view' : 'Current view');
-  const dateFormatOptions = {
-    month: 'long',
-    year: 'numeric',
-    ...((seasonTimezone || timezone) && { timeZone: seasonTimezone || timezone }),
-  };
-  const formattedSeasonWindow = seasonWindow
-    ? `${new Intl.DateTimeFormat(locale, dateFormatOptions).format(seasonWindow.start)} – ${new Intl.DateTimeFormat(locale, dateFormatOptions).format(seasonWindow.end)}`
-    : null;
-  const hasMoreThemes = themes.length > 4;
-  const hasMoreContexts = contextBreakdown.length > 4;
+
+  // Use shared patterns snapshot hook
+  const {
+    timeframeLabel,
+    formattedSeasonWindow,
+    hasMoreContexts,
+    hasMoreThemes,
+    hasMorePatterns,
+  } = usePatternsSnapshot({
+    scopeLabel,
+    seasonWindow,
+    locale,
+    timezone,
+    seasonTimezone,
+    filtersActive,
+    analyticsScope,
+    contextBreakdown,
+    themes,
+  });
 
   const handlePatternsToggle = useCallback(() => {
     setShowAllPatterns((prev) => !prev);
@@ -425,22 +435,10 @@ export default function JourneySidebar({
             <div className="space-y-4">
               {/* Context Breakdown */}
               {contextBreakdown.length > 0 && (
-                <div className="space-y-2">
-                  <ContextBreakdown
-                    data={contextBreakdown}
-                    preferenceDrift={preferenceDrift}
-                  />
-                  {hasMoreContexts && (
-                    <button
-                      type="button"
-                      onClick={handlePatternsToggle}
-                      aria-expanded={showAllPatterns}
-                      className="text-xs font-semibold text-[color:var(--text-accent)] hover:text-main focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
-                    >
-                      {showAllPatterns ? 'Hide focus areas' : 'View all focus areas'}
-                    </button>
-                  )}
-                </div>
+                <ContextBreakdown
+                  data={contextBreakdown}
+                  preferenceDrift={preferenceDrift}
+                />
               )}
 
               {/* Themes */}
@@ -457,62 +455,32 @@ export default function JourneySidebar({
                       </span>
                     ))}
                   </div>
-                  {hasMoreThemes && (
-                    <button
-                      type="button"
-                      onClick={handlePatternsToggle}
-                      aria-expanded={showAllPatterns}
-                      className="mt-2 text-xs font-semibold text-[color:var(--text-accent)] hover:text-main focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
-                    >
-                      {showAllPatterns ? 'Hide themes' : 'View all themes'}
-                    </button>
-                  )}
                 </div>
               )}
 
-              {showAllPatterns && (hasMoreContexts || hasMoreThemes) && (
-                <div className="rounded-2xl border border-[color:var(--border-warm-light)] bg-[color:var(--border-warm-subtle)] p-4 space-y-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-high">
-                        Full Patterns Snapshot
-                      </p>
-                      <p className="text-[11px] text-muted">
-                        Timeframe: {timeframeLabel}
-                        {formattedSeasonWindow ? ` · ${formattedSeasonWindow}` : ''}
-                      </p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={handlePatternsToggle}
-                      className="flex h-7 w-7 items-center justify-center rounded-full text-muted hover:text-main hover:bg-[color:var(--border-warm-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
-                      aria-label="Close full patterns snapshot"
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                  {contextBreakdown.length > 0 && (
-                    <ContextBreakdown
-                      data={contextBreakdown}
-                      preferenceDrift={preferenceDrift}
-                      maxItems={contextBreakdown.length}
-                    />
-                  )}
-                  {themes.length > 0 && (
-                    <div>
-                      <p className="text-xs text-muted mb-2">All Themes</p>
-                      <div className="flex flex-wrap gap-1.5">
-                        {themes.map((theme, i) => (
-                          <span
-                            key={`${theme}-${i}`}
-                            className="rounded-full bg-[color:var(--panel-dark-3)] px-2.5 py-1 text-xs text-muted-high"
-                          >
-                            {theme}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
+              {/* Single "View full patterns" / "Hide patterns" button */}
+              {hasMorePatterns && (
+                <button
+                  type="button"
+                  onClick={handlePatternsToggle}
+                  aria-expanded={showAllPatterns}
+                  className="text-xs font-semibold text-[color:var(--text-accent)] hover:text-main focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
+                >
+                  {showAllPatterns ? 'Hide patterns' : 'View full patterns'}
+                </button>
+              )}
+
+              {/* Expanded patterns snapshot using shared component */}
+              {showAllPatterns && hasMorePatterns && (
+                <PatternsSnapshotPanel
+                  timeframeLabel={timeframeLabel}
+                  formattedSeasonWindow={formattedSeasonWindow}
+                  contextBreakdown={contextBreakdown}
+                  themes={themes}
+                  preferenceDrift={preferenceDrift}
+                  onClose={handlePatternsToggle}
+                />
+              )}
                 </div>
               )}
 

--- a/src/components/ReadingJourney/hooks/usePatternsSnapshot.js
+++ b/src/components/ReadingJourney/hooks/usePatternsSnapshot.js
@@ -1,0 +1,54 @@
+/**
+ * usePatternsSnapshot - Shared hook for patterns snapshot logic.
+ *
+ * Computes timeframe labels, date formatting, and determines whether
+ * the expanded patterns view should be available.
+ */
+
+import { useMemo } from 'react';
+
+export function usePatternsSnapshot({
+  scopeLabel,
+  seasonWindow,
+  locale = 'default',
+  timezone,
+  seasonTimezone,
+  filtersActive,
+  analyticsScope,
+  contextBreakdown = [],
+  themes = [],
+}) {
+  const timeframeLabel = useMemo(
+    () =>
+      scopeLabel ||
+      (filtersActive && analyticsScope === 'filters' ? 'Filtered view' : 'Current view'),
+    [scopeLabel, filtersActive, analyticsScope]
+  );
+
+  const dateFormatOptions = useMemo(
+    () => ({
+      month: 'long',
+      year: 'numeric',
+      ...((seasonTimezone || timezone) && { timeZone: seasonTimezone || timezone }),
+    }),
+    [seasonTimezone, timezone]
+  );
+
+  const formattedSeasonWindow = useMemo(() => {
+    if (!seasonWindow) return null;
+    const formatter = new Intl.DateTimeFormat(locale, dateFormatOptions);
+    return `${formatter.format(seasonWindow.start)} – ${formatter.format(seasonWindow.end)}`;
+  }, [seasonWindow, locale, dateFormatOptions]);
+
+  const hasMoreContexts = contextBreakdown.length > 4;
+  const hasMoreThemes = themes.length > 4;
+  const hasMorePatterns = hasMoreContexts || hasMoreThemes;
+
+  return {
+    timeframeLabel,
+    formattedSeasonWindow,
+    hasMoreContexts,
+    hasMoreThemes,
+    hasMorePatterns,
+  };
+}

--- a/src/components/ReadingJourney/sections/ContextBreakdown.jsx
+++ b/src/components/ReadingJourney/sections/ContextBreakdown.jsx
@@ -19,19 +19,20 @@ function getContextColor(context) {
   return CONTEXT_COLORS[context?.toLowerCase()] || CONTEXT_COLORS.general;
 }
 
-function ContextBreakdown({ data = [], preferenceDrift }) {
+function ContextBreakdown({ data = [], preferenceDrift, maxItems = 4 }) {
   if (!data.length) return null;
 
   // Sort by count descending
   const sorted = [...data].sort((a, b) => b.count - a.count);
   const total = sorted.reduce((sum, item) => sum + item.count, 0);
+  const normalizedMaxItems = typeof maxItems === 'number' ? maxItems : sorted.length;
 
   return (
     <div>
       <p className="text-xs text-muted mb-3">Your Focus Areas</p>
 
       <div className="space-y-2">
-        {sorted.slice(0, 4).filter(item => item?.name).map((item) => {
+        {sorted.slice(0, normalizedMaxItems).filter(item => item?.name).map((item) => {
           const percentage = total > 0 ? Math.round((item.count / total) * 100) : 0;
           const contextName = item.name.charAt(0).toUpperCase() + item.name.slice(1);
 

--- a/src/components/ReadingJourney/sections/PatternsSnapshotPanel.jsx
+++ b/src/components/ReadingJourney/sections/PatternsSnapshotPanel.jsx
@@ -1,0 +1,66 @@
+/**
+ * PatternsSnapshotPanel - Shared expanded patterns snapshot panel.
+ *
+ * Shows the full context breakdown and theme list with timeframe information.
+ */
+
+import { memo } from 'react';
+import { X } from '@phosphor-icons/react';
+import ContextBreakdown from './ContextBreakdown';
+
+function PatternsSnapshotPanel({
+  timeframeLabel,
+  formattedSeasonWindow,
+  contextBreakdown = [],
+  themes = [],
+  preferenceDrift,
+  onClose,
+}) {
+  return (
+    <div className="rounded-2xl border border-[color:var(--border-warm-light)] bg-[color:var(--border-warm-subtle)] p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-high">
+            Full Patterns Snapshot
+          </p>
+          <p className="text-[11px] text-muted">
+            Timeframe: {timeframeLabel}
+            {formattedSeasonWindow ? ` · ${formattedSeasonWindow}` : ''}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-7 w-7 items-center justify-center rounded-full text-muted hover:text-main hover:bg-[color:var(--border-warm-light)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-45)]"
+          aria-label="Close full patterns snapshot"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {contextBreakdown.length > 0 && (
+        <ContextBreakdown
+          data={contextBreakdown}
+          preferenceDrift={preferenceDrift}
+          maxItems={contextBreakdown.length}
+        />
+      )}
+      {themes.length > 0 && (
+        <div>
+          <p className="text-xs text-muted mb-2">All Themes</p>
+          <div className="flex flex-wrap gap-1.5">
+            {themes.map((theme, i) => (
+              <span
+                key={`${theme}-${i}`}
+                className="rounded-full bg-[color:var(--panel-dark-3)] px-2.5 py-1 text-xs text-muted-high"
+              >
+                {theme}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(PatternsSnapshotPanel);


### PR DESCRIPTION
### Motivation
- Provide a way for users to see the full Themes and Context distribution beyond the top-4 snippets in the Reading Journey UI.
- Surface a simple timeframe label derived from the current scope/season window so the expanded view is self-explanatory.
- Reuse existing `ContextBreakdown` rendering logic while allowing it to show the full distribution when requested.

### Description
- Added a `maxItems` prop to `ContextBreakdown` and defaulted it to `4`, allowing callers to request the full list by passing `maxItems={data.length}` in `src/components/ReadingJourney/sections/ContextBreakdown.jsx`.
- Introduced `showAllPatterns` state and a `handlePatternsToggle` handler in both `src/components/ReadingJourney/JourneySidebar.jsx` and `src/components/ReadingJourney/JourneyMobileSheet.jsx` to toggle an expanded snapshot.
- Added “View all focus areas” / “View all themes” affordances (and matching “Hide …” actions) that reveal a compact full snapshot containing the complete context breakdown and the full theme list with a timeframe label computed from `scopeLabel` and `seasonWindow` (uses `Intl.DateTimeFormat` for localized month/year formatting).
- Minor UI updates: imported the `X` icon for the snapshot close control and added styling blocks to render the expanded snapshot in both desktop and mobile variants.

### Testing
- Launched the frontend dev server with `npm run dev:frontend` which started Vite successfully (server reachable at the reported URL). (Succeeded)
- Ran a Playwright script that loaded `/journal` and captured a screenshot (`journey-patterns.png`) to validate the mobile/desktop sheet rendering; the screenshot artifact was produced despite an unrelated proxy warning from Vite. (Succeeded)
- No unit tests were run for this UI-only change (`npm test` was not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a0f0201c83289dee28a2413d1819)

## Summary by Sourcery

Add an expandable full patterns snapshot to the Reading Journey sidebar and mobile views, allowing users to see complete context and theme distributions with timeframe metadata.

New Features:
- Allow ContextBreakdown to render either a truncated or full list of focus areas via a configurable maxItems prop.
- Add "View all" / "Hide" controls in Reading Journey sidebar and mobile patterns tab to toggle an expanded patterns snapshot.
- Display a full patterns snapshot panel that shows all focus areas and themes along with a derived timeframe label and season date range on both desktop and mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added expandable full patterns view in Reading Journey displaying complete context breakdown and themes.
  * Patterns view includes formatted timeframe information for reference.
  * New toggle buttons to show or hide expanded patterns in both mobile and sidebar interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->