### PR TITLE
feat(journal): show local save time and use user-facing Cloud/Synced labels

### DIFF
--- a/src/components/Journal.jsx
+++ b/src/components/Journal.jsx
@@ -67,6 +67,7 @@ export default function Journal() {
     hasTotalEntries,
     error: journalError,
     lastSyncAt,
+    lastLocalSaveAt,
     syncSource,
     reload: reloadJournal
   } = useJournal();
@@ -799,6 +800,7 @@ export default function Journal() {
             isAuthenticated={isAuthenticated}
             canUseCloudJournal={canUseCloudJournal}
             lastSyncAt={lastSyncAt}
+            lastLocalSaveAt={lastLocalSaveAt}
             syncSource={syncSource}
             journalError={journalError}
             loading={loading}

--- a/src/components/journal/JournalStatusBanner.jsx
+++ b/src/components/journal/JournalStatusBanner.jsx
@@ -15,6 +15,7 @@ export function JournalStatusBanner({
   isAuthenticated,
   canUseCloudJournal,
   lastSyncAt,
+  lastLocalSaveAt,
   syncSource,
   journalError,
   loading,
@@ -57,24 +58,35 @@ export function JournalStatusBanner({
     const hour = 60 * minute;
     const day = 24 * hour;
     if (diff < minute) return 'just now';
-    if (diff < hour) return `${Math.round(diff / minute)}m ago`;
-    if (diff < day) return `${Math.round(diff / hour)}h ago`;
-    return `${Math.round(diff / day)}d ago`;
+    if (diff < hour) {
+      const minutes = Math.round(diff / minute);
+      return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+    }
+    if (diff < day) {
+      const hours = Math.round(diff / hour);
+      return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+    }
+    const days = Math.round(diff / day);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
   }, [now]);
 
   const syncTimeLabel = lastSyncAt ? formatRelativeTime(lastSyncAt) : null;
+  const localSaveLabel = lastLocalSaveAt ? `Saved locally ${formatRelativeTime(lastLocalSaveAt)}` : null;
   const syncParts = [];
   if (isCloudEnabled && (loading || !syncSource)) {
     syncParts.push('Syncing');
-    syncParts.push('D1');
+    syncParts.push('Cloud');
   } else if (!isAuthenticated || !canUseCloudJournal || syncSource === 'local') {
     syncParts.push('Local only');
+    if (localSaveLabel) {
+      syncParts.push(localSaveLabel);
+    }
   } else if (syncSource === 'cache') {
     syncParts.push('Cached');
-    syncParts.push('D1');
+    syncParts.push('Cloud');
   } else {
     syncParts.push('Synced');
-    syncParts.push('D1');
+    syncParts.push('Cloud');
   }
   if (syncTimeLabel && isCloudEnabled && syncSource !== 'local') {
     syncParts.push(syncTimeLabel);


### PR DESCRIPTION
### Motivation

- Replace internal storage label `D1` with clear, user-facing labels like `Cloud`/`Synced`/`Local only` so users understand sync state. 
- Surface a `lastLocalSaveAt` timestamp for local-only users so the banner can show "Saved locally X minutes ago" after local writes.

### Description

- Updated `src/components/journal/JournalStatusBanner.jsx` to accept a new `lastLocalSaveAt` prop, replace occurrences of the internal `D1` label with `Cloud`/`Synced`, and show a `Saved locally <relative time>` segment when appropriate. 
- Improved `formatRelativeTime` in the banner to render pluralized minutes/hours/days (e.g. `1 minute ago`, `2 hours ago`).
- Updated `src/hooks/useJournal.js` to track `lastLocalSaveAt` and set it when writing to localStorage on local saves, deletes, and legacy imports, and exposed it from the hook return value. 
- Passed `lastLocalSaveAt` through `src/components/Journal.jsx` into the banner so the UI can render the local-save label.

### Testing

- Started the frontend dev server with `npm run dev:frontend` and used an automated Playwright script to navigate to `/journal` and capture a screenshot at `artifacts/journal-status-banner.png`, which confirms the banner renders with the updated labels; the screenshot artifact was produced successfully. 
- No unit (`npm test`) or full E2E test suite runs were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a100d4508328ba42875ecca75aa0)

## Summary by Sourcery

Update journal status banner to use user-facing cloud/local labels and display relative timestamps for both cloud syncs and local-only saves.

New Features:
- Display a "Saved locally <relative time>" message in the journal status banner for local-only saves.
- Expose and propagate a lastLocalSaveAt timestamp from the journal hook to the journal status UI.

Enhancements:
- Replace internal "D1" storage labels in the journal status banner with user-friendly "Cloud" and "Synced" labels.
- Improve relative time formatting in the journal status banner to use readable, pluralized units for minutes, hours, and days.