### PR TITLE
feat: refresh card-back design and journal icons

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, useCallback, useLayoutEffect } fr
 import { animate, createSpring, createTimeline, cubicBezier, set } from 'animejs';
 import { ArrowsOut, HandPointing, ArrowLeft, ArrowRight, NotePencil, CaretUp } from '@phosphor-icons/react';
 import { CARD_LOOKUP, FALLBACK_IMAGE, getCardImage } from '../lib/cardLookup';
+import { CardBack } from './CardBack';
 import { CardSymbolInsights } from './CardSymbolInsights';
 import { InteractiveCardOverlay } from './InteractiveCardOverlay';
 import { useReducedMotion } from '../hooks/useReducedMotion';
@@ -567,12 +568,7 @@ export function Card({
                 className="relative w-full max-w-[280px] aspect-[2/3] mx-auto rounded-xl border-2 border-primary/30 shadow-2xl overflow-hidden transition-transform"
                 style={{ transform: `translateX(${swipeOffset * 0.5}px)` }}
               >
-                <img
-                  src="/cardback.png"
-                  alt="Card back - tap or swipe to reveal"
-                  className="w-full h-full object-cover"
-                  loading="eager"
-                />
+                <CardBack className="w-full h-full" />
 
                 {/* Swipe hint arrows */}
                 {showSwipeHint && !prefersReducedMotion && (

--- a/src/components/CardBack.jsx
+++ b/src/components/CardBack.jsx
@@ -1,16 +1,29 @@
+import PropTypes from 'prop-types';
 import { WandsIcon, CupsIcon, SwordsIcon, PentaclesIcon } from './illustrations/SuitIcons';
 
+/**
+ * Presentational component that renders the standard tarot card back.
+ *
+ * Displays the reusable card back design used across the app, featuring a
+ * central celestial sigil and surrounding suit medallions for Wands, Cups,
+ * Swords, and Pentacles.
+ *
+ * @param {Object} props - Component props.
+ * @param {string} [props.className] - Optional additional class names to merge
+ *   with the base `tarot-card-back` styles.
+ * @returns {JSX.Element} The decorative card back markup.
+ */
 export function CardBack({ className = '' }) {
   return (
     <div className={`tarot-card-back ${className}`} aria-hidden="true">
-      <div className="tarot-card-back__frame" aria-hidden="true" />
+      <div className="tarot-card-back__frame" />
       <div className="tarot-card-back__inner">
         <div className="tarot-card-back__sigil">
           <div className="tarot-card-back__sigil-ring" />
           <div className="tarot-card-back__sigil-cross" />
           <div className="tarot-card-back__sigil-orbit" />
         </div>
-        <div className="tarot-card-back__suits" aria-hidden="true">
+        <div className="tarot-card-back__suits">
           <WandsIcon className="tarot-card-back__suit tarot-card-back__suit--wand" />
           <CupsIcon className="tarot-card-back__suit tarot-card-back__suit--cup" />
           <SwordsIcon className="tarot-card-back__suit tarot-card-back__suit--sword" />
@@ -20,3 +33,7 @@ export function CardBack({ className = '' }) {
     </div>
   );
 }
+
+CardBack.propTypes = {
+  className: PropTypes.string,
+};

--- a/src/components/CardBack.jsx
+++ b/src/components/CardBack.jsx
@@ -1,0 +1,22 @@
+import { WandsIcon, CupsIcon, SwordsIcon, PentaclesIcon } from './illustrations/SuitIcons';
+
+export function CardBack({ className = '' }) {
+  return (
+    <div className={`tarot-card-back ${className}`} aria-hidden="true">
+      <div className="tarot-card-back__frame" aria-hidden="true" />
+      <div className="tarot-card-back__inner">
+        <div className="tarot-card-back__sigil">
+          <div className="tarot-card-back__sigil-ring" />
+          <div className="tarot-card-back__sigil-cross" />
+          <div className="tarot-card-back__sigil-orbit" />
+        </div>
+        <div className="tarot-card-back__suits" aria-hidden="true">
+          <WandsIcon className="tarot-card-back__suit tarot-card-back__suit--wand" />
+          <CupsIcon className="tarot-card-back__suit tarot-card-back__suit--cup" />
+          <SwordsIcon className="tarot-card-back__suit tarot-card-back__suit--sword" />
+          <PentaclesIcon className="tarot-card-back__suit tarot-card-back__suit--pentacle" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CardBack.jsx
+++ b/src/components/CardBack.jsx
@@ -13,6 +13,18 @@ import { WandsIcon, CupsIcon, SwordsIcon, PentaclesIcon } from './illustrations/
  *   with the base `tarot-card-back` styles.
  * @returns {JSX.Element} The decorative card back markup.
  */
+/**
+ * Presentational component that renders the standard tarot card back.
+ *
+ * Displays the reusable card back design used across the app, featuring a
+ * central celestial sigil and surrounding suit medallions for Wands, Cups,
+ * Swords, and Pentacles.
+ *
+ * @param {Object} props - Component props.
+ * @param {string} [props.className] - Optional additional class names to merge
+ *   with the base `tarot-card-back` styles.
+ * @returns {JSX.Element} The decorative card back markup.
+ */
 export function CardBack({ className = '' }) {
   return (
     <div className={`tarot-card-back ${className}`} aria-hidden="true">

--- a/src/components/JournalIcons.jsx
+++ b/src/components/JournalIcons.jsx
@@ -1,4 +1,4 @@
-const BASE_STROKE_WIDTH = 1.8;
+const BASE_STROKE_WIDTH = 1.6;
 
 function getBaseSvgProps({ color, weight: _weight, mirrored: _mirrored, ...props } = {}) {
   return {
@@ -16,9 +16,13 @@ export function JournalBookIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <path d="M12 5.2c-2.6-1.2-5.3-1.3-7.5-.4v15.5c2.2-.9 4.9-.8 7.5.4" />
-      <path d="M12 5.2c2.6-1.2 5.3-1.3 7.5-.4v15.5c-2.2-.9-4.9-.8-7.5.4" />
-      <path d="M12 5.2v15.5" />
+      <path d="M4.5 6.5c2.5-1.4 5.6-1.5 7.5-.5v13.8c-2-1-5-.9-7.5.5z" />
+      <path d="M19.5 6.5c-2.5-1.4-5.6-1.5-7.5-.5v13.8c2-1 5-.9 7.5.5z" />
+      <path d="M12 6v14.2" />
+      <path d="M7.5 10h3" />
+      <path d="M13.5 10h3" />
+      <path d="M18 3.8v2.4" />
+      <path d="M16.8 5h2.4" />
     </svg>
   );
 }
@@ -27,10 +31,12 @@ export function JournalCardsAddIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <rect x="9" y="4" width="10" height="14" rx="2" />
-      <rect x="5" y="6" width="10" height="14" rx="2" />
-      <path d="M10.5 13h4" />
-      <path d="M12.5 11v4" />
+      <rect x="8" y="5" width="11" height="15" rx="2.2" />
+      <path d="M5 8V6.5a2 2 0 0 1 2-2h7" />
+      <path d="M13 11v4" />
+      <path d="M11 13h4" />
+      <path d="M18.5 4.2v2" />
+      <path d="M17.5 5.2h2" />
     </svg>
   );
 }
@@ -39,9 +45,9 @@ export function JournalCardAddIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <rect x="6" y="4" width="12" height="16" rx="2" />
-      <path d="M12 8v4" />
-      <path d="M10 10h4" />
+      <rect x="6.5" y="4.5" width="11" height="15" rx="2.2" />
+      <path d="M12 8.5v4" />
+      <path d="M10 10.5h4" />
       <path d="M9.5 15.5h5" />
     </svg>
   );
@@ -51,9 +57,10 @@ export function JournalCardIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <rect x="6" y="4" width="12" height="16" rx="2" />
-      <path d="M9.5 9.5h5" />
-      <path d="M9.5 14.5h5" />
+      <rect x="6.5" y="4.5" width="11" height="15" rx="2.2" />
+      <path d="M9.5 9.2h5" />
+      <path d="M9.5 13.6h5" />
+      <circle cx="12" cy="17.2" r="0.8" />
     </svg>
   );
 }
@@ -63,11 +70,13 @@ export function JournalSlidersIcon(props) {
   return (
     <svg {...svgProps}>
       <path d="M4 7h16" />
-      <circle cx="7.5" cy="7" r="2.1" />
+      <circle cx="8" cy="7" r="2" />
       <path d="M4 12h16" />
-      <circle cx="16.5" cy="12" r="2.1" />
+      <circle cx="15.5" cy="12" r="2" />
       <path d="M4 17h16" />
-      <circle cx="12" cy="17" r="2.1" />
+      <circle cx="11.5" cy="17" r="2" />
+      <path d="M18.5 4.5v2" />
+      <path d="M17.5 5.5h2" />
     </svg>
   );
 }
@@ -77,8 +86,9 @@ export function JournalSearchIcon(props) {
   return (
     <svg {...svgProps}>
       <circle cx="11" cy="11" r="6" />
-      <circle cx="11" cy="11" r="3" opacity="0.65" />
       <path d="M15.5 15.5L20 20" />
+      <path d="M11 8.5v2.5" />
+      <path d="M9.8 9.8h2.5" />
     </svg>
   );
 }
@@ -91,6 +101,8 @@ export function JournalRefreshIcon(props) {
       <path d="M19.5 12a7.5 7.5 0 0 0-13.1-4.6" />
       <path d="M4 17v-5h5" />
       <path d="M4.5 12a7.5 7.5 0 0 0 13.1 4.6" />
+      <path d="M18.2 4.2v2" />
+      <path d="M17.2 5.2h2" />
     </svg>
   );
 }
@@ -102,6 +114,8 @@ export function JournalCommentAddIcon(props) {
       <path d="M6.5 5.5h11a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H10l-4 4v-4H6.5a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2Z" />
       <path d="M12 9v4" />
       <path d="M10 11h4" />
+      <path d="M18 4.2v2" />
+      <path d="M17 5.2h2" />
     </svg>
   );
 }
@@ -110,9 +124,11 @@ export function JournalPlusCircleIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <circle cx="12" cy="12" r="9" />
-      <path d="M12 8v8" />
-      <path d="M8 12h8" />
+      <circle cx="12" cy="12" r="8.8" />
+      <path d="M12 8.5v7" />
+      <path d="M8.5 12h7" />
+      <path d="M18.3 6.2v1.6" />
+      <path d="M17.5 7h1.6" />
     </svg>
   );
 }
@@ -121,10 +137,12 @@ export function JournalPercentCircleIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <circle cx="12" cy="12" r="9" />
+      <circle cx="12" cy="12" r="8.8" />
       <path d="M9 15L15 9" />
-      <circle cx="9.2" cy="9.3" r="1.2" />
-      <circle cx="14.8" cy="14.7" r="1.2" />
+      <circle cx="9.3" cy="9.4" r="1.2" />
+      <circle cx="14.7" cy="14.6" r="1.2" />
+      <path d="M18.3 6.2v1.6" />
+      <path d="M17.5 7h1.6" />
     </svg>
   );
 }
@@ -133,7 +151,8 @@ export function JournalBookmarkIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <path d="M7 4.5h10A1.5 1.5 0 0 1 18.5 6v16l-6.5-3.6L5.5 22V6A1.5 1.5 0 0 1 7 4.5Z" />
+      <path d="M7 4.5h10A1.8 1.8 0 0 1 18.8 6.3v15.2L12 17.7 5.2 21.5V6.3A1.8 1.8 0 0 1 7 4.5Z" />
+      <path d="M9.5 9h5" />
     </svg>
   );
 }
@@ -147,6 +166,8 @@ export function JournalTrashIcon(props) {
       <rect x="7" y="6.5" width="10" height="14.5" rx="2" />
       <path d="M10 10.5v7" />
       <path d="M14 10.5v7" />
+      <path d="M18.3 4.2v2" />
+      <path d="M17.3 5.2h2" />
     </svg>
   );
 }
@@ -155,10 +176,12 @@ export function JournalUserAddIcon(props) {
   const svgProps = getBaseSvgProps(props);
   return (
     <svg {...svgProps}>
-      <path d="M6 12h4" />
-      <path d="M8 10v4" />
+      <path d="M6.5 12h4" />
+      <path d="M8.5 10v4" />
       <circle cx="16" cy="9" r="3" />
       <path d="M11 20a5 5 0 0 1 10 0" />
+      <path d="M18.5 4.2v2" />
+      <path d="M17.5 5.2h2" />
     </svg>
   );
 }
@@ -172,6 +195,51 @@ export function JournalShareIcon(props) {
       <circle cx="17" cy="17" r="2.2" />
       <path d="M8.8 11L15.2 8" />
       <path d="M8.8 13L15.2 16" />
+      <path d="M18.5 4.2v2" />
+      <path d="M17.5 5.2h2" />
+    </svg>
+  );
+}
+
+export function JournalThemesIcon(props) {
+  const svgProps = getBaseSvgProps(props);
+  return (
+    <svg {...svgProps}>
+      <path d="M4.5 8h9" />
+      <circle cx="14" cy="8" r="1.2" />
+      <path d="M4.5 12h11" />
+      <circle cx="16" cy="12" r="1.2" />
+      <path d="M4.5 16h8" />
+      <circle cx="13" cy="16" r="1.2" />
+      <path d="M18.5 6v2" />
+      <path d="M17.5 7h2" />
+      <path d="M18.5 14v2" />
+      <path d="M17.5 15h2" />
+    </svg>
+  );
+}
+
+export function JournalNarrativeIcon(props) {
+  const svgProps = getBaseSvgProps(props);
+  return (
+    <svg {...svgProps}>
+      <path d="M6 6.5h9a3 3 0 0 1 3 3v8" />
+      <path d="M6 6.5v12a2 2 0 0 0 2 2h7" />
+      <path d="M9 10.5h6" />
+      <path d="M9 14h6" />
+      <path d="M15 20.5l3-3" />
+    </svg>
+  );
+}
+
+export function JournalSymbolsIcon(props) {
+  const svgProps = getBaseSvgProps(props);
+  return (
+    <svg {...svgProps}>
+      <circle cx="10.5" cy="11" r="5.5" />
+      <path d="M14.5 15.5L19 20" />
+      <path d="M10.5 8.5v2.5" />
+      <path d="M9.2 9.8h2.6" />
     </svg>
   );
 }

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -12,6 +12,7 @@ import { useTactileLens } from '../hooks/useTactileLens';
 import { MICROCOPY } from '../lib/microcopy';
 import { TactileLensButton, TactileLensOverlay } from './TactileLensOverlay';
 import { SpreadProgressIndicator } from './SpreadProgressIndicator';
+import { CardBack } from './CardBack';
 
 /**
  * Spread layout definitions (x, y as percentage of container)
@@ -864,12 +865,7 @@ export function SpreadTable({
                           transform: 'rotateY(180deg) translateZ(0.1px)'
                         }}
                       >
-                        <img
-                          src="/cardback.png"
-                          alt="Card back"
-                          className="w-full h-full object-cover opacity-90"
-                          loading="lazy"
-                        />
+                        <CardBack className="w-full h-full tarot-card-back--muted" />
                         <div className="absolute inset-0 pointer-events-none flex items-end justify-end p-1.5">
                           {showRevealPill ? (
                             <span className={`${compact ? 'text-[0.55rem] xs:text-[0.6rem]' : 'text-[0.65rem] xs:text-[0.7rem] sm:text-xs-plus'} inline-flex items-center gap-1 rounded-full bg-main/85 text-main font-semibold px-2.5 py-1 shadow-lg border border-primary/30`}>

--- a/src/components/journal/entry-card/EntrySections/KeyThemesSection.jsx
+++ b/src/components/journal/entry-card/EntrySections/KeyThemesSection.jsx
@@ -3,7 +3,7 @@
  * Displays computed theme insights for the reading.
  */
 import { memo } from 'react';
-import { JournalBookIcon } from '../../../JournalIcons';
+import { JournalThemesIcon } from '../../../JournalIcons';
 import { styles, cn } from '../EntryCard.primitives';
 
 export const KeyThemesSection = memo(function KeyThemesSection({ insights }) {
@@ -13,7 +13,7 @@ export const KeyThemesSection = memo(function KeyThemesSection({ insights }) {
     <section className={cn(styles.section, 'mt-4')}>
       <header className={styles.sectionHeader}>
         <div className="flex items-center gap-2">
-          <JournalBookIcon className="h-4 w-4 text-[color:var(--brand-primary)]" aria-hidden="true" />
+          <JournalThemesIcon className="h-4 w-4 text-[color:var(--brand-primary)]" aria-hidden="true" />
           <div className={styles.sectionLabel}>Key themes</div>
         </div>
       </header>

--- a/src/components/journal/entry-card/EntrySections/NarrativeSection.jsx
+++ b/src/components/journal/entry-card/EntrySections/NarrativeSection.jsx
@@ -7,6 +7,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { CaretUp, CaretDown } from '@phosphor-icons/react';
+import { JournalNarrativeIcon } from '../../../JournalIcons';
 import { styles, cn } from '../EntryCard.primitives';
 
 function getNarrativePreviewText(text, maxChars = 260) {
@@ -119,7 +120,10 @@ export const NarrativeSection = memo(function NarrativeSection({
             aria-controls={narrativeId}
             className={styles.sectionHeaderClickable}
           >
-            <div className={styles.sectionLabel}>Reading narrative</div>
+            <div className="flex items-center gap-2">
+              <JournalNarrativeIcon className="h-4 w-4 text-[color:var(--brand-primary)]" aria-hidden="true" />
+              <div className={styles.sectionLabel}>Reading narrative</div>
+            </div>
             <div className="text-[color:var(--text-muted)]">
               {showNarrative ? (
                 <CaretUp className="h-5 w-5" aria-hidden="true" />
@@ -153,7 +157,10 @@ export const NarrativeSection = memo(function NarrativeSection({
       ) : (
         <>
           <header className={styles.sectionHeader}>
-            <div className={styles.sectionLabel}>Reading narrative</div>
+            <div className="flex items-center gap-2">
+              <JournalNarrativeIcon className="h-4 w-4 text-[color:var(--brand-primary)]" aria-hidden="true" />
+              <div className={styles.sectionLabel}>Reading narrative</div>
+            </div>
           </header>
           <div id={narrativeId} className={styles.sectionBody}>
             <div className="prose prose-invert prose-base max-w-none text-[color:var(--text-main)] prose-a:text-[color:var(--brand-primary)] prose-strong:text-[color:var(--text-main)] prose-p:leading-relaxed prose-li:leading-relaxed">

--- a/src/styles/tarot.css
+++ b/src/styles/tarot.css
@@ -1451,9 +1451,10 @@ textarea:focus-visible {
   }
 
   .tarot-card-back {
-    /* Use simpler background on mobile */
-    background: var(--bg-surface-muted);
-    /* Solid fallback */
+    /* Use lighter-weight gradients on mobile */
+    background:
+      radial-gradient(circle at 50% 20%, rgba(255, 214, 156, 0.18), transparent 55%),
+      linear-gradient(160deg, #130b1a 0%, #0b0a16 60%, #070710 100%);
   }
 }
 
@@ -1475,85 +1476,135 @@ textarea:focus-visible {
   }
 }
 
-/* Back: ornate mandala + celestial motif evoking traditional deck backs */
+/* Back: celestial sigil + suit medallion motif for selection cards */
 .tarot-card-back {
   position: relative;
   width: 100%;
   height: 100%;
-  background: radial-gradient(
-      circle at 50% 15%,
-      var(--halo-star-color),
-      transparent 60%
-    ),
-    radial-gradient(circle at 50% 85%, var(--halo-star-color), transparent 60%),
-    repeating-radial-gradient(
-      circle at 50% 50%,
-      var(--brand-secondary),
-      var(--brand-secondary) 1px,
-      transparent 1px,
-      transparent 4px
-    ),
-    radial-gradient(circle at 50% 50%, var(--bg-main), var(--bg-main));
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background:
+    radial-gradient(circle at 18% 16%, rgba(255, 214, 156, 0.26), transparent 58%),
+    radial-gradient(circle at 82% 10%, rgba(138, 118, 255, 0.22), transparent 52%),
+    radial-gradient(circle at 50% 90%, rgba(255, 186, 120, 0.2), transparent 60%),
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.06), transparent 52%),
+    linear-gradient(160deg, #140b1a 0%, #0b0a16 55%, #06060d 100%);
   color: var(--brand-accent);
-  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  overflow: hidden;
 }
 
-.tarot-card-back-symbol {
-  position: relative;
-  width: 64%;
-  height: 64%;
-  border-radius: 999px;
-  border: 1px solid var(--brand-accent);
-  box-shadow: 0 0 14px var(--brand-accent), inset 0 0 18px var(--bg-main);
+.tarot-card-back::before,
+.tarot-card-back::after {
+  content: "";
+  position: absolute;
+  inset: 6%;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 214, 156, 0.28);
+  box-shadow: inset 0 0 16px rgba(255, 212, 167, 0.12);
+  pointer-events: none;
+}
+
+.tarot-card-back::after {
+  inset: 9%;
+  border-color: rgba(255, 214, 156, 0.16);
+  box-shadow: inset 0 0 22px rgba(127, 108, 255, 0.12);
+}
+
+.tarot-card-back__frame {
+  position: absolute;
+  inset: 3.5%;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 214, 156, 0.38);
+  box-shadow:
+    0 0 18px rgba(255, 214, 156, 0.18),
+    inset 0 0 12px rgba(6, 6, 13, 0.6);
+  pointer-events: none;
+}
+
+.tarot-card-back__inner {
+  position: absolute;
+  inset: 12%;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 214, 156, 0.18);
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.05), transparent 65%),
+    linear-gradient(180deg, rgba(12, 10, 22, 0.8), rgba(4, 4, 12, 0.9));
   display: flex;
   align-items: center;
   justify-content: center;
+  color: rgba(255, 214, 156, 0.8);
 }
 
-.tarot-card-back-symbol::before,
-.tarot-card-back-symbol::after {
-  content: "";
-  position: absolute;
-  border-radius: 999px;
-  border: 1px solid var(--brand-secondary);
-}
-
-.tarot-card-back-symbol::before {
-  inset: 12%;
-  border-style: dotted;
-}
-
-.tarot-card-back-symbol::after {
-  inset: 26%;
-  border-style: solid;
-  border-color: var(--brand-accent);
-}
-
-/* Simple cross-wand sigil */
-.tarot-card-back-glyph {
+.tarot-card-back__sigil {
   position: relative;
-  width: 52%;
-  height: 52%;
-}
-
-.tarot-card-back-glyph::before,
-.tarot-card-back-glyph::after {
-  content: "";
-  position: absolute;
-  background-color: var(--brand-accent);
+  width: 58%;
+  height: 58%;
   border-radius: 999px;
-  box-shadow: 0 0 8px var(--brand-accent);
+  border: 1px solid rgba(255, 214, 156, 0.6);
+  box-shadow:
+    0 0 18px rgba(255, 214, 156, 0.3),
+    inset 0 0 18px rgba(255, 214, 156, 0.2);
 }
 
-.tarot-card-back-glyph::before {
-  inset: 2px 47%;
+.tarot-card-back__sigil-ring {
+  position: absolute;
+  inset: 12%;
+  border-radius: 999px;
+  border: 1px dashed rgba(255, 214, 156, 0.5);
 }
 
-.tarot-card-back-glyph::after {
-  inset: 47% 2px;
+.tarot-card-back__sigil-cross {
+  position: absolute;
+  inset: 22%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 214, 156, 0.4);
+}
+
+.tarot-card-back__sigil-orbit {
+  position: absolute;
+  inset: 30%;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 156, 0.65);
+  box-shadow: 0 0 10px rgba(255, 214, 156, 0.35);
+}
+
+.tarot-card-back__suits {
+  position: absolute;
+  bottom: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 156, 0.2);
+  background: rgba(10, 10, 18, 0.6);
+  backdrop-filter: blur(6px);
+}
+
+.tarot-card-back__suit {
+  width: 18px;
+  height: 18px;
+  color: rgba(255, 214, 156, 0.75);
+  filter: drop-shadow(0 0 6px rgba(255, 214, 156, 0.5));
+}
+
+.tarot-card-back__suit--wand {
+  color: rgba(255, 196, 130, 0.9);
+}
+
+.tarot-card-back__suit--cup {
+  color: rgba(140, 196, 255, 0.85);
+}
+
+.tarot-card-back__suit--sword {
+  color: rgba(200, 200, 255, 0.85);
+}
+
+.tarot-card-back__suit--pentacle {
+  color: rgba(255, 214, 156, 0.9);
+}
+
+.tarot-card-back--muted {
+  opacity: 0.9;
 }
 
 /* Face: evokes authentic majors with nameplate, Roman numeral, symbolic band */


### PR DESCRIPTION
### Motivation

- Refresh the visual treatment of card backs used in spread and deck selection to a richer sigil-and-suit motif and ensure the design appears consistently in selection/spread contexts. 
- Update journey / journal iconography to better reflect themed sections (key themes, reading narrative) and provide compact, consistent SVG icons for use across journal views.

### Description

- Added a reusable `CardBack` component at `src/components/CardBack.jsx` and replaced `/cardback.png` usage with `CardBack` in `src/components/Card.jsx` and `src/components/SpreadTable.jsx` so selection and spread UI use the new design. 
- Introduced new CSS rules in `src/styles/tarot.css` to implement the gradient/sigil/suit medallion look and lighter-weight mobile gradients, and added a `tarot-card-back--muted` variant for muted/backface usage. 
- Reworked the journal icon set in `src/components/JournalIcons.jsx` (stroke refinements and new icons `JournalThemesIcon` and `JournalNarrativeIcon`) and wired those icons into the journal components `KeyThemesSection.jsx` and `NarrativeSection.jsx` for the themed headers. 

### Testing

- Started the frontend dev server with `npm run dev:frontend` (Vite) and verified the dev server came up and served the app locally. 
- Attempted an automated Playwright screenshot script to capture spread/deck selection and deck pages, but headless Chromium crashed in this environment so the screenshot run failed. 
- No unit or E2E test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981a5861e148324acbfe84c272b499e)

## Summary by Sourcery

Refresh the card back visual design and journal iconography for tarot spreads and journal views.

New Features:
- Introduce a reusable CardBack component for displaying the new sigil-and-suit card back design across card and spread UIs.
- Add dedicated journal icons for themes and reading narrative sections.

Enhancements:
- Redesign tarot card back styling with layered gradients, sigil framing, and suit medallion details, including a muted variant for backfaces.
- Refine existing journal SVG icons for better visual consistency and legibility across the journal interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable decorative card-back component.
  * Added three new journal icons for Themes, Narrative, and Symbols.

* **Style**
  * Redesigned tarot card back with layered decorative elements and variants.
  * Updated many journal icons with refined strokes and shapes.
  * Replaced some section header icons to improve visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->