### PR TITLE
Add service-account authentication for trusted first-party integrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,3 +401,4 @@ Via `wrangler secret put`:
 - `VISION_PROOF_SECRET`
 - `RESEND_API_KEY` — Email delivery (auth verification/reset)
 - `ADMIN_API_KEY` — Admin endpoints
+- `GPT_SERVICE_TOKEN` — Bearer token for the Tableu Custom GPT / ChatGPT App; authenticates as a synthetic service user entitled at `GPT_SERVICE_TIER` (var, default `plus`). See `functions/lib/serviceAuth.js` and `docs/integrations/openai/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Guidance for Claude Code when working with this repository.
 |-------|------|----------|
 | Frontend | React + Vite | `src/` |
 | Backend | Cloudflare Workers | `functions/api/` |
-| AI | OpenAI GPT-5.4 via Responses API (native or Azure; fallback: Claude/local composer) | `functions/api/tarot-reading.js` |
+| AI | OpenAI GPT-5.6-sol (high reasoning) via Responses API (native or Azure; fallback: Claude/local composer) | `functions/api/tarot-reading.js` |
 | Database | Cloudflare D1 | `migrations/*.sql` |
 | Storage | Cloudflare KV + D1 archival | Metrics, feedback |
 
@@ -115,7 +115,7 @@ npm run gate:design   # Verify design contract compliance
 2. **Ritual** — Knocks + cut position + question → `computeSeed()`
 3. **Draw** — `drawSpread()` uses seeded shuffle, assigns upright/reversed
 4. **Reveal** — Card flip animation, user reflections per card
-5. **Narrative** — OpenAI GPT-5.4 via Responses API (native `OPENAI_API_KEY`, or Azure; fallback: Claude/local composer)
+5. **Narrative** — OpenAI GPT-5.6-sol on high reasoning via Responses API (native `OPENAI_API_KEY`, or Azure; fallback: Claude/local composer)
 
 **Pipeline**: `spreadAnalysis.js` (dignities, reversals) + `knowledgeGraph.js` (patterns) → `graphContext.js` → `graphRAG.js` (passages) → `prompts.js` → AI → `evaluation.js` (async scoring)
 

--- a/docs/integrations/openai/chatgpt-gpt-actions-setup.md
+++ b/docs/integrations/openai/chatgpt-gpt-actions-setup.md
@@ -114,13 +114,29 @@ authenticates as a synthetic service user entitled at that tier
 is not subject to the Pro-only, metered API-key limiter. When
 `GPT_SERVICE_TOKEN` is unset, auth behaves exactly as before.
 
+On first authenticated request the service account is provisioned a real row in
+`users` (id `service:gpt` by default). This is required, not cosmetic: per-user
+tables declare `FOREIGN KEY (user_id) REFERENCES users(id)` and D1 enforces
+foreign keys by default, so without the row every metering and journal write
+fails — and `enforceReadingLimit` swallows that failure, which would hand the
+service account unlimited unmetered readings. The row carries random, unusable
+credentials and a reserved `.invalid` address, so it can never be signed into or
+password-reset.
+
 Notes:
 
 - Use a long, random token. Values shorter than 24 chars are ignored.
 - Reading quota follows the tier: `plus` = 50 readings/mo (tracked under a
   single service-account id), `pro` = unlimited. Override the id with
   `GPT_SERVICE_USER_ID` if you want separate metering.
+- The token is a **machine credential**: account and billing endpoints
+  (profile, password, delete, Stripe checkout/portal, subscription restore)
+  reject it with `401 Session authentication required`, same as an API key.
+- `GPT_SERVICE_EMAIL` is a label for logs only. The backing row's address is
+  always derived from the id so a misconfigured value can't collide with a real
+  account and block provisioning.
 - Rotate by putting a new secret; the old token stops working immediately.
+  Rotation does not change the `users` row, so usage history carries over.
 - Implementation: `functions/lib/serviceAuth.js`, wired in `functions/lib/auth.js`.
 
 ## Instruction pattern to reduce tool-call errors

--- a/docs/integrations/openai/chatgpt-gpt-actions-setup.md
+++ b/docs/integrations/openai/chatgpt-gpt-actions-setup.md
@@ -88,6 +88,41 @@ paths:
 - For per-user identity, use `OAuth`.
 - This backend already accepts `Authorization: Bearer sk_...` (see `functions/lib/auth.js`).
 
+### Service token (recommended for the owner's own GPT)
+
+Per-user `sk_...` API keys are **Pro-only** and must belong to a Stripe-backed
+account, so they can't be minted for a GPT that just needs Plus-level access
+(e.g. the Celtic Cross spread requires Plus). For a trusted first-party
+integration, configure a **service token** instead:
+
+1. Generate a long random secret and set it:
+
+   ```bash
+   openssl rand -hex 32 | wrangler secret put GPT_SERVICE_TOKEN
+   ```
+
+2. (Optional) Choose the entitlement tier — defaults to `plus`, clamped to
+   Plus-or-higher. Set `GPT_SERVICE_TIER` to `pro` in `wrangler.jsonc` to also
+   unlock custom spreads and unlimited readings.
+
+3. In GPT Builder, set the Action auth to **API Key** with **Auth Type:
+   `Bearer`**, and paste the same token value.
+
+Any request presenting `Authorization: Bearer <GPT_SERVICE_TOKEN>` then
+authenticates as a synthetic service user entitled at that tier
+(`auth_provider: 'service'`). It does **not** require a Stripe subscription and
+is not subject to the Pro-only, metered API-key limiter. When
+`GPT_SERVICE_TOKEN` is unset, auth behaves exactly as before.
+
+Notes:
+
+- Use a long, random token. Values shorter than 24 chars are ignored.
+- Reading quota follows the tier: `plus` = 50 readings/mo (tracked under a
+  single service-account id), `pro` = unlimited. Override the id with
+  `GPT_SERVICE_USER_ID` if you want separate metering.
+- Rotate by putting a new secret; the old token stops working immediately.
+- Implementation: `functions/lib/serviceAuth.js`, wired in `functions/lib/auth.js`.
+
 ## Instruction pattern to reduce tool-call errors
 
 - Example:

--- a/functions/api/account/delete.js
+++ b/functions/api/account/delete.js
@@ -12,6 +12,7 @@
  */
 
 import { getUserFromRequest, clearSessionCookie, isSecureRequest } from '../../lib/auth.js';
+import { isMachineCredential } from '../../lib/entitlements.js';
 import { jsonResponse, readJsonBody } from '../../lib/utils.js';
 import { stripeRequest, fetchLatestStripeSubscription } from '../../lib/stripe.js';
 
@@ -153,7 +154,7 @@ export async function onRequestPost(context) {
       return jsonResponse({ error: 'Authentication required' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return jsonResponse({ error: 'Session authentication required' }, { status: 401 });
     }
 

--- a/functions/api/account/password.js
+++ b/functions/api/account/password.js
@@ -18,6 +18,7 @@ import {
   createSessionCookie,
   isSecureRequest
 } from '../../lib/auth.js';
+import { isMachineCredential } from '../../lib/entitlements.js';
 import { jsonResponse, readJsonBody } from '../../lib/utils.js';
 
 export async function onRequestPost(context) {
@@ -30,7 +31,7 @@ export async function onRequestPost(context) {
       return jsonResponse({ error: 'Authentication required' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return jsonResponse({ error: 'Session authentication required' }, { status: 401 });
     }
 

--- a/functions/api/account/profile.js
+++ b/functions/api/account/profile.js
@@ -8,6 +8,7 @@
  */
 
 import { getUserFromRequest, isValidEmail, isValidUsername } from '../../lib/auth.js';
+import { isMachineCredential } from '../../lib/entitlements.js';
 import { jsonResponse, readJsonBody } from '../../lib/utils.js';
 import { sendVerificationEmail } from '../../lib/authNotifications.js';
 
@@ -21,7 +22,7 @@ export async function onRequestPatch(context) {
       return jsonResponse({ error: 'Authentication required' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return jsonResponse({ error: 'Session authentication required' }, { status: 401 });
     }
 

--- a/functions/api/archetype-journey-backfill.js
+++ b/functions/api/archetype-journey-backfill.js
@@ -11,6 +11,7 @@
 
 import { getUserFromRequest } from '../lib/auth.js';
 import { buildCorsHeaders } from '../lib/utils.js';
+import { isMachineCredential } from '../lib/entitlements.js';
 
 /**
  * Parse cards from journal entry
@@ -74,7 +75,7 @@ export async function onRequest(context) {
       });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return new Response(JSON.stringify({ error: 'Session authentication required' }), {
         status: 401,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }

--- a/functions/api/archetype-journey.js
+++ b/functions/api/archetype-journey.js
@@ -13,6 +13,7 @@ import { getUserFromRequest } from '../lib/auth.js';
 import { trackPatterns } from '../lib/patternTracking.js';
 import { enforceApiCallLimit } from '../lib/apiUsage.js';
 import { buildCorsHeaders } from '../lib/utils.js';
+import { isApiKeyUser, isMachineCredential } from '../lib/entitlements.js';
 
 const defaultDeps = { getUserFromRequest };
 
@@ -108,14 +109,18 @@ export async function onRequest(context, deps = defaultDeps) {
       });
     }
 
-    if (user.auth_provider === 'api_key') {
-      // Only allow API key access for card frequency; enforce plan/usage limits.
-      if (!isCardFrequency) {
-        return new Response(JSON.stringify({ error: 'Session authentication required' }), {
-          status: 401,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-        });
-      }
+    // Non-interactive credentials (API keys, service tokens) get card-frequency
+    // access at most; everything else here needs a real session.
+    if (isMachineCredential(user) && !isCardFrequency) {
+      return new Response(JSON.stringify({ error: 'Session authentication required' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Per-key API metering applies to API keys only — service tokens are
+    // exempt by design (see isMachineCredential in lib/entitlements.js).
+    if (isApiKeyUser(user)) {
       const apiLimit = await enforceApiCallLimit(env, user);
       if (!apiLimit.allowed) {
         return new Response(JSON.stringify(apiLimit.payload), {

--- a/functions/api/create-checkout-session.js
+++ b/functions/api/create-checkout-session.js
@@ -34,6 +34,7 @@ import {
   stripeRequest
 } from '../lib/stripe.js';
 import { getTierConfig, isActiveStatus } from '../../shared/monetization/subscription.js';
+import { isMachineCredential } from '../lib/entitlements.js';
 
 const defaultDeps = {
   getUserFromRequest,
@@ -123,7 +124,7 @@ export async function onRequestPost(context, deps = defaultDeps) {
       return toJson({ error: 'Authentication required' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return toJson({ error: 'Session authentication required' }, { status: 401 });
     }
 

--- a/functions/api/create-portal-session.js
+++ b/functions/api/create-portal-session.js
@@ -14,6 +14,7 @@ import { getUserFromRequest } from '../lib/auth.js';
 import { jsonResponse, readJsonBody } from '../lib/utils.js';
 import { sanitizeRedirectUrl } from '../lib/urlSafety.js';
 import { stripeRequest } from '../lib/stripe.js';
+import { isMachineCredential } from '../lib/entitlements.js';
 
 const defaultDeps = {
   getUserFromRequest,
@@ -44,7 +45,7 @@ export async function onRequestPost(context, deps = defaultDeps) {
       return toJson({ error: 'Authentication required', code: 'AUTH_REQUIRED' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return toJson({ error: 'Session authentication required', code: 'SESSION_REQUIRED' }, { status: 401 });
     }
 

--- a/functions/api/subscription.js
+++ b/functions/api/subscription.js
@@ -13,6 +13,7 @@ import {
   extractTierFromSubscription,
   fetchLatestStripeSubscription
 } from '../lib/stripe.js';
+import { isMachineCredential } from '../lib/entitlements.js';
 
 function getStripeDates(subscription) {
   const toMs = (value) => (value ? value * 1000 : null);
@@ -34,7 +35,7 @@ export async function onRequestGet(context) {
       return jsonResponse({ error: 'Authentication required' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return jsonResponse({ error: 'Session authentication required' }, { status: 401 });
     }
 

--- a/functions/api/subscription/restore.js
+++ b/functions/api/subscription/restore.js
@@ -15,6 +15,7 @@ import {
   fetchLatestStripeSubscription
 } from '../../lib/stripe.js';
 import { getClientIdentifier } from '../../lib/clientId.js';
+import { isMachineCredential } from '../../lib/entitlements.js';
 
 const RESTORE_RATE_LIMIT_KEY_PREFIX = 'restore-rate';
 const RESTORE_RATE_LIMIT_MAX = 5;
@@ -69,7 +70,7 @@ export async function onRequestPost(context) {
       return jsonResponse({ error: 'Authentication required' }, { status: 401 });
     }
 
-    if (user.auth_provider === 'api_key') {
+    if (isMachineCredential(user)) {
       return jsonResponse({ error: 'Session authentication required' }, { status: 401 });
     }
 

--- a/functions/lib/auth.js
+++ b/functions/lib/auth.js
@@ -424,11 +424,13 @@ export async function getUserFromRequest(request, env) {
 
     // Service-account path (trusted first-party integrations, e.g. the Custom
     // GPT). Checked before the API-key/session paths — and before the DB guard
-    // below, since service tokens need no database — so an owner-configured
-    // GPT_SERVICE_TOKEN authenticates as a synthetic Plus-or-higher user
-    // without a Stripe-backed account. Skipped for sk_ keys, which are never
-    // service tokens, to avoid needless hashing. No-op unless GPT_SERVICE_TOKEN
-    // is set.
+    // below, since the token itself validates without a database — so an
+    // owner-configured GPT_SERVICE_TOKEN authenticates as a synthetic
+    // Plus-or-higher user without a Stripe-backed account. When env.DB *is*
+    // present this also provisions the backing users row that metering and
+    // journal writes need (see serviceAuth.ensureServiceUserRow). Skipped for
+    // sk_ keys, which are never service tokens, to avoid needless hashing.
+    // No-op unless GPT_SERVICE_TOKEN is set.
     if (token && !token.startsWith('sk_')) {
       const serviceUser = await resolveServiceUser(token, env);
       if (serviceUser) {

--- a/functions/lib/auth.js
+++ b/functions/lib/auth.js
@@ -1,5 +1,6 @@
 import { validateApiKey } from './apiKeys.js';
 import { timingSafeEqual } from './crypto.js';
+import { resolveServiceUser } from './serviceAuth.js';
 
 /**
  * Authentication library for Mystic Tarot
@@ -426,6 +427,15 @@ export async function getUserFromRequest(request, env) {
   // Authorization: Bearer <token>
   if (authHeader && authHeader.startsWith('Bearer ')) {
     const token = authHeader.split(' ')[1];
+
+    // Service-account path (trusted first-party integrations, e.g. the Custom
+    // GPT). Checked before the API-key/session paths so an owner-configured
+    // GPT_SERVICE_TOKEN authenticates as a synthetic Plus-or-higher user
+    // without a Stripe-backed account. No-op unless GPT_SERVICE_TOKEN is set.
+    const serviceUser = await resolveServiceUser(token, env);
+    if (serviceUser) {
+      return serviceUser;
+    }
 
     // API key path (Bearer sk_...)
     if (token && token.startsWith('sk_')) {

--- a/functions/lib/auth.js
+++ b/functions/lib/auth.js
@@ -416,12 +416,6 @@ export function isValidPassword(password) {
  * @returns {Promise<object|null>} User object or null if unauthenticated
  */
 export async function getUserFromRequest(request, env) {
-  // Defensive check: return null if DB is not available
-  // This prevents errors in routes that don't have DB binding
-  if (!env?.DB) {
-    return null;
-  }
-
   const authHeader = request.headers.get('Authorization');
 
   // Authorization: Bearer <token>
@@ -429,12 +423,24 @@ export async function getUserFromRequest(request, env) {
     const token = authHeader.split(' ')[1];
 
     // Service-account path (trusted first-party integrations, e.g. the Custom
-    // GPT). Checked before the API-key/session paths so an owner-configured
+    // GPT). Checked before the API-key/session paths — and before the DB guard
+    // below, since service tokens need no database — so an owner-configured
     // GPT_SERVICE_TOKEN authenticates as a synthetic Plus-or-higher user
-    // without a Stripe-backed account. No-op unless GPT_SERVICE_TOKEN is set.
-    const serviceUser = await resolveServiceUser(token, env);
-    if (serviceUser) {
-      return serviceUser;
+    // without a Stripe-backed account. Skipped for sk_ keys, which are never
+    // service tokens, to avoid needless hashing. No-op unless GPT_SERVICE_TOKEN
+    // is set.
+    if (token && !token.startsWith('sk_')) {
+      const serviceUser = await resolveServiceUser(token, env);
+      if (serviceUser) {
+        return serviceUser;
+      }
+    }
+
+    // The remaining Bearer paths (API key, session token) need the DB.
+    // Defensive check: return null if DB is not available (routes without a
+    // DB binding).
+    if (!env?.DB) {
+      return null;
     }
 
     // API key path (Bearer sk_...)
@@ -467,10 +473,11 @@ export async function getUserFromRequest(request, env) {
     }
   }
 
-  // Fallback to session cookie
+  // Fallback to session cookie (needs the DB, so re-assert the guard here now
+  // that the top-level check has moved below the DB-less service path).
   const cookieHeader = request.headers.get('Cookie');
   const sessionToken = getSessionFromCookie(cookieHeader);
-  if (!sessionToken) return null;
+  if (!sessionToken || !env?.DB) return null;
 
   return validateSession(env.DB, sessionToken);
 }

--- a/functions/lib/azureResponses.js
+++ b/functions/lib/azureResponses.js
@@ -1,6 +1,6 @@
 import { fetchWithRetry } from './retryWithBackoff.js';
 
-export const OPENAI_DEFAULT_MODEL = 'gpt-5.5';
+export const OPENAI_DEFAULT_MODEL = 'gpt-5.6-sol';
 
 /**
  * Validate and normalize Responses API configuration.
@@ -100,6 +100,17 @@ export function resolveResponsesUser(env = null, explicitUser = null) {
  * @returns {string} Reasoning effort level ('none'|'minimal'|'low'|'medium'|'high'|'xhigh')
  */
 export function getReasoningEffort(env = null, modelName = '') {
+  // Native OpenAI override takes priority when OPENAI_API_KEY is configured,
+  // mirroring how OPENAI_STREAMING_ENABLED precedes the legacy Azure flag. This
+  // lets the OpenAI-native path (e.g. gpt-5.6-sol on 'high') be tuned
+  // independently of the Azure fallback's AZURE_OPENAI_REASONING_EFFORT.
+  const nativeOverride = env?.OPENAI_API_KEY && typeof env?.OPENAI_REASONING_EFFORT === 'string'
+    ? env.OPENAI_REASONING_EFFORT.trim().toLowerCase()
+    : null;
+  if (nativeOverride && VALID_REASONING_EFFORTS.has(nativeOverride)) {
+    return nativeOverride;
+  }
+
   const rawOverride = typeof env?.AZURE_OPENAI_REASONING_EFFORT === 'string'
     ? env.AZURE_OPENAI_REASONING_EFFORT.trim().toLowerCase()
     : null;
@@ -123,6 +134,16 @@ export function getReasoningEffort(env = null, modelName = '') {
  * @returns {string} Verbosity level ('low'|'medium'|'high')
  */
 export function getTextVerbosity(env = null, modelName = '') {
+  // Native OpenAI override takes priority when OPENAI_API_KEY is configured
+  // (parallels getReasoningEffort), so the OpenAI-native path can set verbosity
+  // independently of the Azure fallback's AZURE_OPENAI_VERBOSITY.
+  const nativeOverride = env?.OPENAI_API_KEY && typeof env?.OPENAI_VERBOSITY === 'string'
+    ? env.OPENAI_VERBOSITY.trim().toLowerCase()
+    : null;
+  if (nativeOverride && VALID_VERBOSITY_LEVELS.has(nativeOverride)) {
+    return nativeOverride;
+  }
+
   const rawOverride = typeof env?.AZURE_OPENAI_VERBOSITY === 'string'
     ? env.AZURE_OPENAI_VERBOSITY.trim().toLowerCase()
     : null;

--- a/functions/lib/crypto.js
+++ b/functions/lib/crypto.js
@@ -46,3 +46,21 @@ export function timingSafeEqual(a, b) {
 
   return result === 0;
 }
+
+/**
+ * Compute the SHA-256 hash of a string and return it as lowercase hex.
+ *
+ * Useful for reducing secrets of arbitrary length to a fixed-width digest
+ * before a constant-time comparison, so the comparison itself cannot leak
+ * the secret's length through timing.
+ *
+ * @param {string} value - Input string to hash
+ * @returns {Promise<string>} Hex-encoded SHA-256 digest (64 chars)
+ */
+export async function sha256Hex(value) {
+  const data = new TextEncoder().encode(String(value));
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/functions/lib/entitlements.js
+++ b/functions/lib/entitlements.js
@@ -28,6 +28,21 @@ export function isApiKeyUser(user) {
   return user?.auth_provider === 'api_key';
 }
 
+export function isServiceUser(user) {
+  return user?.auth_provider === 'service';
+}
+
+// Non-interactive credentials: API keys and service tokens. Neither is tied to
+// a human session, so neither may perform account or billing operations
+// (profile edits, password changes, deletion, Stripe checkout/portal).
+//
+// Note this is deliberately NOT the check for the Pro-only metered API-call
+// limiter — that one stays `isApiKeyUser`, since service tokens are exempt from
+// per-key API metering by design.
+export function isMachineCredential(user) {
+  return isApiKeyUser(user) || isServiceUser(user);
+}
+
 export function isEntitled(user, requiredTier) {
   const { effectiveTier } = getSubscriptionContext(user);
   return hasTierAtLeast(effectiveTier, requiredTier);

--- a/functions/lib/serviceAuth.js
+++ b/functions/lib/serviceAuth.js
@@ -59,6 +59,25 @@ export function isServiceAuthConfigured(env) {
   return token.length >= MIN_SERVICE_TOKEN_LENGTH;
 }
 
+// Warn at most once per isolate about a misconfigured (too-short) token —
+// matchesServiceToken runs on every Bearer request, so an unconditional warn
+// would spam logs (and log-ingestion cost) on each one.
+let hasWarnedShortToken = false;
+
+// The configured token is static for the isolate's lifetime, so memoize its
+// digest instead of re-hashing it on every request. Keyed on the raw value so a
+// rotated token (new value) recomputes rather than returning a stale hash.
+let cachedExpectedToken = null;
+let cachedExpectedHashPromise = null;
+
+function getExpectedTokenHash(configuredToken) {
+  if (configuredToken !== cachedExpectedToken) {
+    cachedExpectedToken = configuredToken;
+    cachedExpectedHashPromise = sha256Hex(configuredToken);
+  }
+  return cachedExpectedHashPromise;
+}
+
 /**
  * Constant-time check that a presented bearer token matches the configured
  * service token. Both sides are SHA-256 hashed first so the comparison is
@@ -71,7 +90,8 @@ export function isServiceAuthConfigured(env) {
 export async function matchesServiceToken(token, env) {
   if (typeof token !== 'string' || !token) return false;
   if (!isServiceAuthConfigured(env)) {
-    if (typeof env?.GPT_SERVICE_TOKEN === 'string' && env.GPT_SERVICE_TOKEN.length > 0) {
+    if (typeof env?.GPT_SERVICE_TOKEN === 'string' && env.GPT_SERVICE_TOKEN.length > 0 && !hasWarnedShortToken) {
+      hasWarnedShortToken = true;
       console.warn(
         `[serviceAuth] GPT_SERVICE_TOKEN is set but shorter than the ${MIN_SERVICE_TOKEN_LENGTH}-char minimum; ignoring it.`
       );
@@ -81,7 +101,7 @@ export async function matchesServiceToken(token, env) {
 
   const [presented, expected] = await Promise.all([
     sha256Hex(token),
-    sha256Hex(env.GPT_SERVICE_TOKEN)
+    getExpectedTokenHash(env.GPT_SERVICE_TOKEN)
   ]);
   return timingSafeEqual(presented, expected);
 }

--- a/functions/lib/serviceAuth.js
+++ b/functions/lib/serviceAuth.js
@@ -1,0 +1,130 @@
+/**
+ * Service-account authentication for trusted first-party integrations.
+ *
+ * The Tableu Custom GPT / ChatGPT App calls this backend with a static bearer
+ * token (documented as a "service account" in
+ * docs/integrations/openai/*). Unlike per-user API keys — which derive their
+ * entitlements from a Stripe-backed user record and are Pro-only — a service
+ * token is an owner-controlled shared secret that authenticates as a synthetic
+ * user entitled at a fixed tier (Plus by default, Pro if configured).
+ *
+ * This is a deliberate, out-of-band entitlement grant: it lets the owner's own
+ * GPT reach subscription-gated spreads (e.g. Celtic Cross needs Plus) without
+ * provisioning a paying account or minting a DB-backed key. It is only active
+ * when `GPT_SERVICE_TOKEN` is configured; when unset, auth behaves exactly as
+ * before.
+ *
+ * Env vars:
+ * - `GPT_SERVICE_TOKEN`  (secret)   Shared bearer token the GPT presents. When
+ *                                   absent/empty, service auth is disabled.
+ * - `GPT_SERVICE_TIER`   (var)      'plus' (default) or 'pro'. Never downgrades
+ *                                   below Plus — the whole point is Plus-or-higher.
+ * - `GPT_SERVICE_USER_ID`(var)      Optional stable id for usage tracking.
+ * - `GPT_SERVICE_EMAIL`  (var)      Optional email stamped on the synthetic user.
+ */
+
+import { sha256Hex, timingSafeEqual } from './crypto.js';
+import { normalizeTier } from '../../shared/monetization/subscription.js';
+
+// Reject trivially short/guessable tokens even if misconfigured. A real token
+// should be long and random (e.g. `openssl rand -hex 32`).
+export const MIN_SERVICE_TOKEN_LENGTH = 24;
+
+// Service accounts are entitled at Plus-or-higher by contract.
+const DEFAULT_SERVICE_TIER = 'plus';
+const ALLOWED_SERVICE_TIERS = new Set(['plus', 'pro']);
+const DEFAULT_SERVICE_USER_ID = 'service:gpt';
+
+/**
+ * Resolve the entitlement tier for the service account.
+ * Clamps to Plus minimum so a typo or `free` value can't silently strip the
+ * elevated access the service token exists to provide.
+ *
+ * @param {object} env - Worker environment bindings
+ * @returns {'plus'|'pro'}
+ */
+export function resolveServiceTier(env) {
+  const configured = normalizeTier(env?.GPT_SERVICE_TIER);
+  return ALLOWED_SERVICE_TIERS.has(configured) ? configured : DEFAULT_SERVICE_TIER;
+}
+
+/**
+ * Whether service-token auth is configured (and usable) for this environment.
+ *
+ * @param {object} env - Worker environment bindings
+ * @returns {boolean}
+ */
+export function isServiceAuthConfigured(env) {
+  const token = typeof env?.GPT_SERVICE_TOKEN === 'string' ? env.GPT_SERVICE_TOKEN : '';
+  return token.length >= MIN_SERVICE_TOKEN_LENGTH;
+}
+
+/**
+ * Constant-time check that a presented bearer token matches the configured
+ * service token. Both sides are SHA-256 hashed first so the comparison is
+ * fixed-width and cannot leak the token length through timing.
+ *
+ * @param {string} token - Bearer token presented by the caller
+ * @param {object} env - Worker environment bindings
+ * @returns {Promise<boolean>}
+ */
+export async function matchesServiceToken(token, env) {
+  if (typeof token !== 'string' || !token) return false;
+  if (!isServiceAuthConfigured(env)) {
+    if (typeof env?.GPT_SERVICE_TOKEN === 'string' && env.GPT_SERVICE_TOKEN.length > 0) {
+      console.warn(
+        `[serviceAuth] GPT_SERVICE_TOKEN is set but shorter than the ${MIN_SERVICE_TOKEN_LENGTH}-char minimum; ignoring it.`
+      );
+    }
+    return false;
+  }
+
+  const [presented, expected] = await Promise.all([
+    sha256Hex(token),
+    sha256Hex(env.GPT_SERVICE_TOKEN)
+  ]);
+  return timingSafeEqual(presented, expected);
+}
+
+/**
+ * Build the synthetic user object for an authenticated service request.
+ * Shaped to match the user records returned elsewhere by `getUserFromRequest`
+ * so downstream entitlement/subscription logic treats it uniformly.
+ *
+ * `auth_provider: 'service'` (not 'api_key') keeps it clear of the Pro-only,
+ * metered API-key limiter in the reading pipeline while remaining observable
+ * in logs.
+ *
+ * @param {object} env - Worker environment bindings
+ * @returns {object} Synthetic user
+ */
+export function buildServiceUser(env) {
+  const tier = resolveServiceTier(env);
+  const rawId = typeof env?.GPT_SERVICE_USER_ID === 'string' ? env.GPT_SERVICE_USER_ID.trim() : '';
+  const rawEmail = typeof env?.GPT_SERVICE_EMAIL === 'string' ? env.GPT_SERVICE_EMAIL.trim() : '';
+  return {
+    id: rawId || DEFAULT_SERVICE_USER_ID,
+    email: rawEmail || null,
+    username: 'gpt-service',
+    subscription_tier: tier,
+    subscription_status: 'active',
+    subscription_provider: 'service',
+    stripe_customer_id: null,
+    email_verified: true,
+    auth_provider: 'service',
+    is_service_account: true
+  };
+}
+
+/**
+ * Resolve a service user from a bearer token, or null when the token does not
+ * match (or service auth is not configured).
+ *
+ * @param {string} token - Bearer token presented by the caller
+ * @param {object} env - Worker environment bindings
+ * @returns {Promise<object|null>}
+ */
+export async function resolveServiceUser(token, env) {
+  const matched = await matchesServiceToken(token, env);
+  return matched ? buildServiceUser(env) : null;
+}

--- a/functions/lib/serviceAuth.js
+++ b/functions/lib/serviceAuth.js
@@ -14,13 +14,24 @@
  * when `GPT_SERVICE_TOKEN` is configured; when unset, auth behaves exactly as
  * before.
  *
+ * The synthetic identity is backed by a real `users` row, provisioned on first
+ * use (see `ensureServiceUserRow`). Most per-user tables — `usage_tracking`,
+ * `journal_entries`, `card_appearances`, … — declare
+ * `FOREIGN KEY (user_id) REFERENCES users(id)`, and D1 enforces foreign keys by
+ * default. Without that row every such write fails with
+ * `FOREIGN KEY constraint failed`; for `usage_tracking` in particular the
+ * failure is swallowed by `enforceReadingLimit`, which would silently hand the
+ * service account unlimited unmetered readings.
+ *
  * Env vars:
  * - `GPT_SERVICE_TOKEN`  (secret)   Shared bearer token the GPT presents. When
  *                                   absent/empty, service auth is disabled.
  * - `GPT_SERVICE_TIER`   (var)      'plus' (default) or 'pro'. Never downgrades
  *                                   below Plus — the whole point is Plus-or-higher.
  * - `GPT_SERVICE_USER_ID`(var)      Optional stable id for usage tracking.
- * - `GPT_SERVICE_EMAIL`  (var)      Optional email stamped on the synthetic user.
+ * - `GPT_SERVICE_EMAIL`  (var)      Optional email stamped on the synthetic user
+ *                                   for observability. The backing row always
+ *                                   uses a derived, collision-proof address.
  */
 
 import { sha256Hex, timingSafeEqual } from './crypto.js';
@@ -34,6 +45,10 @@ export const MIN_SERVICE_TOKEN_LENGTH = 24;
 const DEFAULT_SERVICE_TIER = 'plus';
 const ALLOWED_SERVICE_TIERS = new Set(['plus', 'pro']);
 const DEFAULT_SERVICE_USER_ID = 'service:gpt';
+
+// Per-isolate memo of service ids whose `users` row is known to exist, so the
+// provisioning round-trip happens once per isolate rather than per request.
+const ensuredServiceUserIds = new Set();
 
 /**
  * Resolve the entitlement tier for the service account.
@@ -137,6 +152,114 @@ export function buildServiceUser(env) {
 }
 
 /**
+ * Username stamped on the backing `users` row.
+ *
+ * Always contains a colon, which `isValidUsername` (`/^[a-zA-Z0-9_]{3,30}$/`)
+ * rejects — so the value can never collide with a username a real account can
+ * register, whatever `GPT_SERVICE_USER_ID` is set to.
+ *
+ * @param {string} id - Service user id
+ * @returns {string}
+ */
+function serviceRowUsername(id) {
+  return id.includes(':') ? id : `service:${id}`;
+}
+
+/**
+ * Email stamped on the backing `users` row. Derived rather than taken from
+ * `GPT_SERVICE_EMAIL` so a misconfigured value can't collide with a real
+ * account's address and quietly block provisioning. `.invalid` is reserved by
+ * RFC 2606, so it is never deliverable — no password reset can be routed to it.
+ *
+ * @param {string} id - Service user id
+ * @returns {string}
+ */
+function serviceRowEmail(id) {
+  return `${serviceRowUsername(id)}@service.invalid`;
+}
+
+/** @returns {string} 32 unguessable random bytes, hex-encoded */
+function unusableSecret() {
+  return Array.from(crypto.getRandomValues(new Uint8Array(32)))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Ensure a `users` row exists for the service account.
+ *
+ * Per-user tables carry `FOREIGN KEY (user_id) REFERENCES users(id)` and D1
+ * enforces foreign keys by default, so without this row the service account
+ * cannot be metered (`enforceReadingLimit` swallows the constraint failure and
+ * allows the request) and journal saves fail with a 500.
+ *
+ * `password_hash`/`password_salt` are fresh random bytes with no known
+ * preimage, so the row can never be used to sign in; the derived `.invalid`
+ * email means no reset mail can be delivered either.
+ *
+ * Best-effort: a failure here is logged loudly but does not fail the request —
+ * the token itself is still valid. It must never fail *silently*, since that is
+ * exactly the quota-bypass this function exists to prevent.
+ *
+ * @param {object} env - Worker environment bindings (requires env.DB)
+ * @param {object} user - Synthetic user from `buildServiceUser`
+ * @returns {Promise<boolean>} Whether the row is present
+ */
+export async function ensureServiceUserRow(env, user) {
+  const db = env?.DB;
+  const id = user?.id;
+  if (!db || !id) return false;
+  if (ensuredServiceUserIds.has(id)) return true;
+
+  try {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    // OR IGNORE makes concurrent cold starts idempotent: the loser of the race
+    // is a no-op rather than a primary-key error.
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO users (
+           id, email, username, password_hash, password_salt,
+           created_at, updated_at, is_active, email_verified,
+           subscription_tier, subscription_status, subscription_provider, auth_provider
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1, ?, 'active', 'service', 'service')`
+      )
+      .bind(
+        id,
+        serviceRowEmail(id),
+        serviceRowUsername(id),
+        unusableSecret(),
+        unusableSecret(),
+        nowSeconds,
+        nowSeconds,
+        user.subscription_tier
+      )
+      .run();
+
+    // Verify rather than trust: OR IGNORE also swallows a unique-constraint
+    // collision on email/username, which would leave the FK unsatisfied.
+    const row = await db.prepare('SELECT id FROM users WHERE id = ?').bind(id).first();
+    if (!row) {
+      console.error(
+        `[serviceAuth] Could not provision the users row for "${id}" — it is still absent after INSERT OR IGNORE, ` +
+        'likely a unique-constraint collision on email/username. Reading quota will not be enforced and journal ' +
+        'saves will fail until this is resolved.'
+      );
+      return false;
+    }
+
+    ensuredServiceUserIds.add(id);
+    return true;
+  } catch (error) {
+    console.error(
+      `[serviceAuth] Failed to provision the users row for "${id}": ${error?.message || error}. ` +
+      'Reading quota will not be enforced and journal saves will fail until this is resolved.'
+    );
+    return false;
+  }
+}
+
+/**
  * Resolve a service user from a bearer token, or null when the token does not
  * match (or service auth is not configured).
  *
@@ -146,5 +269,11 @@ export function buildServiceUser(env) {
  */
 export async function resolveServiceUser(token, env) {
   const matched = await matchesServiceToken(token, env);
-  return matched ? buildServiceUser(env) : null;
+  if (!matched) return null;
+
+  const user = buildServiceUser(env);
+  // Awaited, not fire-and-forget: downstream writes on this same request
+  // (usage_tracking, journal_entries) need the row to already exist.
+  await ensureServiceUserRow(env, user);
+  return user;
 }

--- a/tarot-reading-openapi.yaml
+++ b/tarot-reading-openapi.yaml
@@ -176,6 +176,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: API Key
+      description: >
+        Bearer token. Either a per-user API key (`sk_...`, Pro-only) or the
+        configured service token (`GPT_SERVICE_TOKEN`), which authenticates as a
+        Plus-or-higher service account. Send as `Authorization: Bearer <token>`.
   schemas:
     CreateTarotReadingRequest:
       type: object

--- a/tests/azureResponses.test.mjs
+++ b/tests/azureResponses.test.mjs
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict';
 import {
   ensureAzureConfig,
   getReasoningEffort,
+  getTextVerbosity,
   resolveResponsesUser
 } from '../functions/lib/azureResponses.js';
 
@@ -179,9 +180,63 @@ describe('getReasoningEffort', () => {
     assert.strictEqual(getReasoningEffort(null, 'custom-model'), 'medium');
   });
 
+  test('returns high for gpt-5.6-sol (the native default model)', () => {
+    assert.strictEqual(getReasoningEffort(null, 'gpt-5.6-sol'), 'high');
+  });
+
   test('respects env override', () => {
     const env = { AZURE_OPENAI_REASONING_EFFORT: 'low' };
     assert.strictEqual(getReasoningEffort(env, 'gpt-5.2'), 'low');
+  });
+
+  test('prefers OPENAI_REASONING_EFFORT on the native path', () => {
+    const env = {
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_REASONING_EFFORT: 'high',
+      AZURE_OPENAI_REASONING_EFFORT: 'xhigh'
+    };
+    assert.strictEqual(getReasoningEffort(env, 'gpt-5.6-sol'), 'high');
+  });
+
+  test('ignores OPENAI_REASONING_EFFORT when OPENAI_API_KEY is absent (Azure fallback keeps its setting)', () => {
+    const env = {
+      OPENAI_REASONING_EFFORT: 'high',
+      AZURE_OPENAI_REASONING_EFFORT: 'xhigh'
+    };
+    assert.strictEqual(getReasoningEffort(env, 'gpt-5'), 'xhigh');
+  });
+
+  test('falls back to AZURE_OPENAI_REASONING_EFFORT on the native path when no native override', () => {
+    const env = {
+      OPENAI_API_KEY: 'sk-test',
+      AZURE_OPENAI_REASONING_EFFORT: 'medium'
+    };
+    assert.strictEqual(getReasoningEffort(env, 'gpt-5.6-sol'), 'medium');
+  });
+
+  test('ignores an invalid native override and falls through to the model default', () => {
+    const env = { OPENAI_API_KEY: 'sk-test', OPENAI_REASONING_EFFORT: 'bogus' };
+    assert.strictEqual(getReasoningEffort(env, 'gpt-5.6-sol'), 'high');
+  });
+});
+
+describe('getTextVerbosity', () => {
+  test('defaults to low for GPT-5 variants', () => {
+    assert.strictEqual(getTextVerbosity(null, 'gpt-5.6-sol'), 'low');
+  });
+
+  test('prefers OPENAI_VERBOSITY on the native path', () => {
+    const env = {
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_VERBOSITY: 'high',
+      AZURE_OPENAI_VERBOSITY: 'medium'
+    };
+    assert.strictEqual(getTextVerbosity(env, 'gpt-5.6-sol'), 'high');
+  });
+
+  test('ignores OPENAI_VERBOSITY when OPENAI_API_KEY is absent', () => {
+    const env = { OPENAI_VERBOSITY: 'high', AZURE_OPENAI_VERBOSITY: 'medium' };
+    assert.strictEqual(getTextVerbosity(env, 'gpt-5.6-sol'), 'medium');
   });
 });
 

--- a/tests/openaiProviderConfig.test.mjs
+++ b/tests/openaiProviderConfig.test.mjs
@@ -33,21 +33,29 @@ function runConfigCheck(devVarsText) {
 }
 
 describe('native OpenAI provider configuration', () => {
-  it('uses GPT-5.5 as the default native OpenAI Responses model', () => {
+  it('uses gpt-5.6-sol as the default native OpenAI Responses model', () => {
     const config = ensureAzureConfig({
       OPENAI_API_KEY: 'openai-test-key'
     });
 
     assert.equal(config.provider, 'openai-native');
-    assert.equal(config.model, 'gpt-5.5');
+    assert.equal(config.model, 'gpt-5.6-sol');
     assert.equal(config.url, 'https://api.openai.com/v1/responses');
     assert.deepEqual(config.authHeaders, { Authorization: 'Bearer openai-test-key' });
+  });
+
+  it('honors an explicit OPENAI_MODEL override', () => {
+    const config = ensureAzureConfig({
+      OPENAI_API_KEY: 'openai-test-key',
+      OPENAI_MODEL: 'gpt-5.6-sol-preview'
+    });
+    assert.equal(config.model, 'gpt-5.6-sol-preview');
   });
 
   it('accepts OPENAI_API_KEY as sufficient for AI-generated readings in config checks', () => {
     const output = runConfigCheck([
       'OPENAI_API_KEY=sk-test',
-      'OPENAI_MODEL=gpt-5.5'
+      'OPENAI_MODEL=gpt-5.6-sol'
     ].join('\n'));
 
     assert.match(output, /AI-generated readings \(OpenAI native\):/);

--- a/tests/serviceAuth.test.mjs
+++ b/tests/serviceAuth.test.mjs
@@ -113,6 +113,22 @@ test('getUserFromRequest authenticates the service token as a Plus user', async 
   assert.strictEqual(subscription.config.spreads, 'all');
 });
 
+test('getUserFromRequest authenticates the service token without a DB binding', async () => {
+  // Service tokens need no database, so they must resolve even on routes/envs
+  // where env.DB is absent.
+  const env = { GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);
+  assert.ok(user, 'service token should authenticate without a DB binding');
+  assert.strictEqual(user.auth_provider, 'service');
+  assert.strictEqual(user.subscription_tier, 'plus');
+});
+
+test('getUserFromRequest returns null for a non-service Bearer token when DB is absent', async () => {
+  const env = { GPT_SERVICE_TOKEN: SERVICE_TOKEN }; // no DB
+  const user = await getUserFromRequest(bearer('sk_live_whatever'), env);
+  assert.strictEqual(user, null, 'API-key/session paths still require the DB');
+});
+
 test('getUserFromRequest honors GPT_SERVICE_TIER=pro', async () => {
   const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN, GPT_SERVICE_TIER: 'pro' };
   const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);

--- a/tests/serviceAuth.test.mjs
+++ b/tests/serviceAuth.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { webcrypto } from 'node:crypto';
+
+import { getUserFromRequest } from '../functions/lib/auth.js';
+import {
+  buildServiceUser,
+  matchesServiceToken,
+  resolveServiceTier,
+  resolveServiceUser,
+  MIN_SERVICE_TOKEN_LENGTH
+} from '../functions/lib/serviceAuth.js';
+import { getSubscriptionContext } from '../functions/lib/entitlements.js';
+
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+
+// A realistic long random token (>= MIN_SERVICE_TOKEN_LENGTH chars).
+const SERVICE_TOKEN = 'svc_0123456789abcdef0123456789abcdef01234567';
+
+// D1 stub that never matches a session/api-key, so non-service tokens resolve
+// to null and we can prove the service path is what's authenticating.
+class NullDB {
+  prepare() {
+    return {
+      bind: () => ({
+        first: async () => null,
+        run: async () => ({ meta: { changes: 0 } }),
+        all: async () => ({ results: [] })
+      })
+    };
+  }
+}
+
+function bearer(token) {
+  return new Request('https://example.com/api/tarot-reading', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+test('resolveServiceTier defaults to plus and clamps below-Plus values', () => {
+  assert.strictEqual(resolveServiceTier({}), 'plus');
+  assert.strictEqual(resolveServiceTier({ GPT_SERVICE_TIER: 'plus' }), 'plus');
+  assert.strictEqual(resolveServiceTier({ GPT_SERVICE_TIER: 'pro' }), 'pro');
+  assert.strictEqual(resolveServiceTier({ GPT_SERVICE_TIER: ' PRO ' }), 'pro');
+  // Never downgrade below Plus, even if misconfigured.
+  assert.strictEqual(resolveServiceTier({ GPT_SERVICE_TIER: 'free' }), 'plus');
+  assert.strictEqual(resolveServiceTier({ GPT_SERVICE_TIER: 'nonsense' }), 'plus');
+});
+
+test('matchesServiceToken is exact, and disabled unless configured', async () => {
+  const env = { GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  assert.strictEqual(await matchesServiceToken(SERVICE_TOKEN, env), true);
+  assert.strictEqual(await matchesServiceToken(`${SERVICE_TOKEN}x`, env), false);
+  assert.strictEqual(await matchesServiceToken('wrong', env), false);
+  assert.strictEqual(await matchesServiceToken('', env), false);
+
+  // Not configured => never matches.
+  assert.strictEqual(await matchesServiceToken(SERVICE_TOKEN, {}), false);
+
+  // Too-short configured token is ignored (defense against weak secrets).
+  const shortToken = 'a'.repeat(MIN_SERVICE_TOKEN_LENGTH - 1);
+  assert.strictEqual(
+    await matchesServiceToken(shortToken, { GPT_SERVICE_TOKEN: shortToken }),
+    false
+  );
+});
+
+test('buildServiceUser shapes a Plus-or-higher synthetic user', () => {
+  const plus = buildServiceUser({ GPT_SERVICE_TOKEN: SERVICE_TOKEN });
+  assert.strictEqual(plus.subscription_tier, 'plus');
+  assert.strictEqual(plus.subscription_status, 'active');
+  assert.strictEqual(plus.subscription_provider, 'service');
+  assert.strictEqual(plus.auth_provider, 'service');
+  assert.strictEqual(plus.email_verified, true);
+  assert.strictEqual(plus.is_service_account, true);
+  assert.strictEqual(plus.id, 'service:gpt');
+
+  const pro = buildServiceUser({ GPT_SERVICE_TIER: 'pro' });
+  assert.strictEqual(pro.subscription_tier, 'pro');
+
+  const custom = buildServiceUser({
+    GPT_SERVICE_USER_ID: 'service:my-gpt',
+    GPT_SERVICE_EMAIL: 'gpt@example.com'
+  });
+  assert.strictEqual(custom.id, 'service:my-gpt');
+  assert.strictEqual(custom.email, 'gpt@example.com');
+});
+
+test('resolveServiceUser returns null on mismatch, user on match', async () => {
+  const env = { GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  assert.strictEqual(await resolveServiceUser('nope', env), null);
+  const user = await resolveServiceUser(SERVICE_TOKEN, env);
+  assert.ok(user);
+  assert.strictEqual(user.auth_provider, 'service');
+});
+
+test('getUserFromRequest authenticates the service token as a Plus user', async () => {
+  const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);
+
+  assert.ok(user, 'service token should authenticate');
+  assert.strictEqual(user.auth_provider, 'service');
+  assert.strictEqual(user.subscription_tier, 'plus');
+  assert.strictEqual(user.subscription_status, 'active');
+
+  // The whole point: a Plus service user is entitled to every built-in spread,
+  // including the Celtic Cross that was previously blocked.
+  const subscription = getSubscriptionContext(user);
+  assert.strictEqual(subscription.effectiveTier, 'plus');
+  assert.strictEqual(subscription.config.spreads, 'all');
+});
+
+test('getUserFromRequest honors GPT_SERVICE_TIER=pro', async () => {
+  const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN, GPT_SERVICE_TIER: 'pro' };
+  const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);
+  assert.strictEqual(user.subscription_tier, 'pro');
+  assert.strictEqual(getSubscriptionContext(user).effectiveTier, 'pro');
+});
+
+test('getUserFromRequest ignores the token when service auth is not configured', async () => {
+  const env = { DB: new NullDB() }; // no GPT_SERVICE_TOKEN
+  const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);
+  assert.strictEqual(user, null, 'without configuration the token must not authenticate');
+});
+
+test('getUserFromRequest rejects a wrong bearer token', async () => {
+  const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  const user = await getUserFromRequest(bearer('Bearer-but-wrong-token-value-1234567890'), env);
+  assert.strictEqual(user, null);
+});

--- a/tests/serviceAuth.test.mjs
+++ b/tests/serviceAuth.test.mjs
@@ -5,12 +5,18 @@ import { webcrypto } from 'node:crypto';
 import { getUserFromRequest } from '../functions/lib/auth.js';
 import {
   buildServiceUser,
+  ensureServiceUserRow,
   matchesServiceToken,
   resolveServiceTier,
   resolveServiceUser,
   MIN_SERVICE_TOKEN_LENGTH
 } from '../functions/lib/serviceAuth.js';
-import { getSubscriptionContext } from '../functions/lib/entitlements.js';
+import {
+  getSubscriptionContext,
+  isApiKeyUser,
+  isMachineCredential,
+  isServiceUser
+} from '../functions/lib/entitlements.js';
 
 if (!globalThis.crypto) {
   globalThis.crypto = webcrypto;
@@ -98,7 +104,7 @@ test('resolveServiceUser returns null on mismatch, user on match', async () => {
 });
 
 test('getUserFromRequest authenticates the service token as a Plus user', async () => {
-  const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  const env = envWithId('service:plus-entitlement');
   const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);
 
   assert.ok(user, 'service token should authenticate');
@@ -130,7 +136,7 @@ test('getUserFromRequest returns null for a non-service Bearer token when DB is 
 });
 
 test('getUserFromRequest honors GPT_SERVICE_TIER=pro', async () => {
-  const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN, GPT_SERVICE_TIER: 'pro' };
+  const env = envWithId('service:pro-entitlement', { GPT_SERVICE_TIER: 'pro' });
   const user = await getUserFromRequest(bearer(SERVICE_TOKEN), env);
   assert.strictEqual(user.subscription_tier, 'pro');
   assert.strictEqual(getSubscriptionContext(user).effectiveTier, 'pro');
@@ -146,4 +152,169 @@ test('getUserFromRequest rejects a wrong bearer token', async () => {
   const env = { DB: new NullDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN };
   const user = await getUserFromRequest(bearer('Bearer-but-wrong-token-value-1234567890'), env);
   assert.strictEqual(user, null);
+});
+
+// ---------------------------------------------------------------------------
+// Backing users row.
+//
+// Per-user tables declare FOREIGN KEY (user_id) REFERENCES users(id) and D1
+// enforces foreign keys by default. Without a real row, usage_tracking writes
+// throw, enforceReadingLimit swallows the error and returns allowed:true — so
+// the service account would get unlimited unmetered readings — and journal
+// saves 500. These tests pin the row into existence.
+// ---------------------------------------------------------------------------
+
+/** Minimal D1 double backing just the `users` table, with UNIQUE emulation. */
+class FakeDB {
+  constructor(seedUsers = []) {
+    this.users = new Map(seedUsers.map((u) => [u.id, u]));
+    this.statements = [];
+  }
+
+  prepare(sql) {
+    const db = this;
+    return {
+      bind(...args) {
+        return {
+          async run() {
+            db.statements.push({ sql, args });
+            if (/INSERT OR IGNORE INTO users/i.test(sql)) {
+              const [id, email, username, password_hash, password_salt] = args;
+              const collides = [...db.users.values()].some(
+                (u) => u.email === email || u.username === username
+              );
+              if (db.users.has(id) || collides) return { meta: { changes: 0 } };
+              db.users.set(id, { id, email, username, password_hash, password_salt });
+              return { meta: { changes: 1 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+          async first() {
+            db.statements.push({ sql, args });
+            if (/SELECT id FROM users WHERE id = \?/i.test(sql)) {
+              return db.users.get(args[0]) || null;
+            }
+            return null;
+          },
+          async all() {
+            return { results: [] };
+          }
+        };
+      }
+    };
+  }
+
+  insertCount() {
+    return this.statements.filter((s) => /INSERT OR IGNORE INTO users/i.test(s.sql)).length;
+  }
+}
+
+// Provisioning is memoized per isolate, so every test uses a distinct id.
+function envWithId(id, extra = {}) {
+  return { DB: new FakeDB(), GPT_SERVICE_TOKEN: SERVICE_TOKEN, GPT_SERVICE_USER_ID: id, ...extra };
+}
+
+test('resolveServiceUser provisions a backing users row so FK-bound writes succeed', async () => {
+  const env = envWithId('service:provision-test');
+  const user = await resolveServiceUser(SERVICE_TOKEN, env);
+
+  assert.ok(user);
+  const row = env.DB.users.get('service:provision-test');
+  assert.ok(row, 'a users row must exist or every metered write fails the FK');
+  assert.strictEqual(row.id, user.id);
+});
+
+test('the provisioned row cannot be signed into or password-reset', async () => {
+  const env = envWithId('service:credentials-test');
+  await resolveServiceUser(SERVICE_TOKEN, env);
+  const row = env.DB.users.get('service:credentials-test');
+
+  // Reserved TLD (RFC 2606) — no reset mail is ever deliverable.
+  assert.match(row.email, /@service\.invalid$/);
+  // A colon is rejected by isValidUsername, so no real signup can collide.
+  assert.ok(row.username.includes(':'));
+  // Random with no known preimage: no password can ever derive these.
+  assert.match(row.password_hash, /^[0-9a-f]{64}$/);
+  assert.match(row.password_salt, /^[0-9a-f]{64}$/);
+  assert.notStrictEqual(row.password_hash, row.password_salt);
+});
+
+test('an id without a colon is still namespaced away from real usernames', async () => {
+  const env = envWithId('mygpt');
+  await resolveServiceUser(SERVICE_TOKEN, env);
+  const row = env.DB.users.get('mygpt');
+  assert.strictEqual(row.username, 'service:mygpt');
+  assert.strictEqual(row.email, 'service:mygpt@service.invalid');
+});
+
+test('GPT_SERVICE_EMAIL labels the user object but never the backing row', async () => {
+  const env = envWithId('service:email-test', { GPT_SERVICE_EMAIL: 'owner@example.com' });
+  const user = await resolveServiceUser(SERVICE_TOKEN, env);
+
+  assert.strictEqual(user.email, 'owner@example.com');
+  // Deriving the row address keeps a misconfigured value from colliding with a
+  // real account and silently blocking provisioning.
+  assert.strictEqual(env.DB.users.get('service:email-test').email, 'service:email-test@service.invalid');
+});
+
+test('provisioning is memoized per isolate', async () => {
+  const env = envWithId('service:memo-test');
+  await resolveServiceUser(SERVICE_TOKEN, env);
+  const afterFirst = env.DB.insertCount();
+  await resolveServiceUser(SERVICE_TOKEN, env);
+  await resolveServiceUser(SERVICE_TOKEN, env);
+
+  assert.strictEqual(afterFirst, 1);
+  assert.strictEqual(env.DB.insertCount(), 1, 'later requests must not re-issue the insert');
+});
+
+test('a unique collision fails loudly rather than silently', async () => {
+  // A real account already holding the derived address blocks the insert;
+  // INSERT OR IGNORE would swallow that, which is the exact silent failure the
+  // verify-after-insert exists to catch.
+  const db = new FakeDB([
+    { id: 'someone-else', email: 'service:collide@service.invalid', username: 'realuser' }
+  ]);
+  const env = { DB: db, GPT_SERVICE_TOKEN: SERVICE_TOKEN, GPT_SERVICE_USER_ID: 'service:collide' };
+
+  const errors = [];
+  const originalError = console.error;
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    const ok = await ensureServiceUserRow(env, buildServiceUser(env));
+    assert.strictEqual(ok, false);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.strictEqual(errors.length, 1);
+  assert.match(errors[0], /could not provision/i);
+});
+
+test('ensureServiceUserRow is a no-op without a DB binding', async () => {
+  const env = { GPT_SERVICE_TOKEN: SERVICE_TOKEN };
+  assert.strictEqual(await ensureServiceUserRow(env, buildServiceUser(env)), false);
+});
+
+// ---------------------------------------------------------------------------
+// Machine-credential guardrails.
+// ---------------------------------------------------------------------------
+
+test('service tokens count as machine credentials, like API keys', () => {
+  const service = { auth_provider: 'service' };
+  const apiKey = { auth_provider: 'api_key' };
+  const session = { auth_provider: 'email' };
+
+  assert.strictEqual(isMachineCredential(service), true);
+  assert.strictEqual(isMachineCredential(apiKey), true);
+  assert.strictEqual(isMachineCredential(session), false);
+  assert.strictEqual(isMachineCredential(null), false);
+
+  assert.strictEqual(isServiceUser(service), true);
+  assert.strictEqual(isServiceUser(apiKey), false);
+
+  // Per-key API metering must stay API-key-only: service tokens are exempt by
+  // design, so broadening this would start charging them per call.
+  assert.strictEqual(isApiKeyUser(service), false);
+  assert.strictEqual(isApiKeyUser(apiKey), true);
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -101,6 +101,17 @@
     "ENABLE_TTS_DEBUG_LOGGING": "false",
     "ENABLE_SPEECH_TOKEN_DEBUG": "false",
     // -------------------------------------------------------------------------
+    // Service-account auth for the Tableu Custom GPT / ChatGPT App.
+    // When the GPT_SERVICE_TOKEN secret is set, requests bearing it
+    // (Authorization: Bearer <token>) authenticate as a synthetic service user
+    // entitled at GPT_SERVICE_TIER. This unblocks subscription-gated spreads
+    // (e.g. Celtic Cross needs Plus) for the owner's own GPT without a
+    // Stripe-backed account. Tier is clamped to Plus-or-higher: 'plus' | 'pro'.
+    // Optional overrides: GPT_SERVICE_USER_ID (usage-tracking id),
+    // GPT_SERVICE_EMAIL. See docs/integrations/openai/.
+    // -------------------------------------------------------------------------
+    "GPT_SERVICE_TIER": "plus",
+    // -------------------------------------------------------------------------
     // Vision validation backend settings (server-side only; UI still pins clip-default)
     // -------------------------------------------------------------------------
     "VISION_TIMEOUT_MS": "12000",
@@ -262,6 +273,10 @@
   //
   // Other
   // wrangler secret put VISION_PROOF_SECRET
+  //
+  // Custom GPT / ChatGPT App service-account token (Plus-or-higher access).
+  // Use a long random value, e.g. `openssl rand -hex 32`. Tier via GPT_SERVICE_TIER.
+  // wrangler secret put GPT_SERVICE_TOKEN
   //
   // Admin (for manual archival trigger)
   // wrangler secret put ADMIN_API_KEY

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -58,17 +58,21 @@
     "AZURE_OPENAI_TTS_RESPONSES_API_VERSION": "",
     "OPENAI_STREAMING_ENABLED": "true",
     "AZURE_OPENAI_STREAMING_ENABLED": "true",
-    // AZURE_OPENAI_REASONING_EFFORT: Controls reasoning depth for narrative generation
-    // Valid values: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'
+    // AZURE_OPENAI_REASONING_EFFORT: Controls reasoning depth for the Azure
+    // fallback path. Valid values: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'
     "AZURE_OPENAI_REASONING_EFFORT": "xhigh",
     // ---------------------------------------------------------------------
     // OpenAI native Responses API (takes priority when OPENAI_API_KEY secret is set)
     // OPENAI_BASE_URL defaults to https://api.openai.com if empty.
-    // OPENAI_MODEL is the model id sent in the request body (e.g. "gpt-5.5").
+    // OPENAI_MODEL is the model id sent in the request body (e.g. "gpt-5.6-sol").
+    // OPENAI_REASONING_EFFORT overrides reasoning depth on the native path
+    // (falls back to AZURE_OPENAI_REASONING_EFFORT, then the model default).
+    // OPENAI_VERBOSITY optionally overrides text verbosity on the native path.
     // Azure config remains as fallback when OPENAI_API_KEY is absent.
     // ---------------------------------------------------------------------
     "OPENAI_BASE_URL": "https://api.openai.com",
-    "OPENAI_MODEL": "gpt-5.5",
+    "OPENAI_MODEL": "gpt-5.6-sol",
+    "OPENAI_REASONING_EFFORT": "high",
     "ALLOW_STREAMING_WITH_EVAL_GATE": "true",
     "STREAMING_QUALITY_GATE_ENABLED": "false",
     "STREAMING_SAFETY_SCAN_ENABLED": "false",


### PR DESCRIPTION
## Summary

Introduces service-account authentication for trusted first-party integrations (e.g., the Tableu Custom GPT / ChatGPT App). This allows the owner's own GPT to access subscription-gated spreads (like Celtic Cross, which requires Plus) without provisioning a Stripe-backed account or minting a per-user API key.

When `GPT_SERVICE_TOKEN` is configured, requests bearing it as a Bearer token authenticate as a synthetic service user entitled at a fixed tier (Plus by default, Pro if configured). This is an out-of-band entitlement grant that only activates when explicitly configured; when unset, auth behaves exactly as before.

## Key Changes

- **New module `functions/lib/serviceAuth.js`**: Implements service-account authentication with:
  - `resolveServiceTier()` — Resolves entitlement tier (Plus or Pro), clamped to Plus minimum
  - `isServiceAuthConfigured()` — Checks if service auth is enabled
  - `matchesServiceToken()` — Constant-time token comparison using SHA-256 hashing
  - `buildServiceUser()` — Constructs synthetic user object with `auth_provider: 'service'`
  - `resolveServiceUser()` — Resolves a bearer token to a service user or null
  - `MIN_SERVICE_TOKEN_LENGTH` constant (24 chars) to reject trivially weak secrets

- **Updated `functions/lib/auth.js`**: Integrated service-account path into `getUserFromRequest()` before API-key/session paths, so service tokens authenticate without requiring a Stripe-backed account

- **New `functions/lib/crypto.js` export**: Added `sha256Hex()` utility for fixed-width token hashing before constant-time comparison

- **Comprehensive test suite `tests/serviceAuth.test.mjs`**: 133 lines covering:
  - Tier resolution and clamping behavior
  - Token matching (exact, disabled when unconfigured, rejects short tokens)
  - Service user construction with custom id/email overrides
  - Integration with `getUserFromRequest()` and subscription entitlements
  - Proper rejection of wrong/missing tokens

- **Documentation & configuration**:
  - Updated `docs/integrations/openai/chatgpt-gpt-actions-setup.md` with setup instructions (generate token, configure tier, set GPT Builder auth)
  - Added `GPT_SERVICE_TIER` and related env var documentation to `wrangler.jsonc`
  - Updated OpenAPI spec to clarify Bearer token usage

- **Model & reasoning updates**:
  - Bumped default OpenAI model from `gpt-5.5` to `gpt-5.6-sol` (higher reasoning capability)
  - Added `OPENAI_REASONING_EFFORT` and `OPENAI_VERBOSITY` overrides for native OpenAI path (independent of Azure fallback)
  - Updated `functions/lib/azureResponses.js` to respect native overrides when `OPENAI_API_KEY` is configured
  - Updated test expectations in `tests/azureResponses.test.mjs` and `tests/openaiProviderConfig.test.mjs`

## Implementation Details

- **Security**: Tokens are SHA-256 hashed before comparison to prevent timing attacks that could leak token length
- **Tier clamping**: Service accounts are always Plus-or-higher; misconfiguration (e.g., `free` or typos) safely defaults to Plus
- **Minimal footprint**: Service auth is a no-op unless `GPT_SERVICE_TOKEN` is set; existing auth paths unchanged
- **Synthetic user shape**: Matches the structure returned by other `getUserFromRequest()` paths so downstream entitlement/subscription logic treats it uniformly
- **Metering**: Service users are tracked under a single configurable id (default `service:gpt`), with reading quota following the tier (50/mo for Plus, unlimited for Pro)

## Notes

- Reading quota and usage tracking follow the configured tier
- Rotate tokens by putting a new secret; the old token stops working immediately
- Implementation is wired into the auth flow but only active when configured

https://claude.ai/code/session_016DedYJR6za3cTio3xfbUVe