### PR TITLE
Add prompt debug diagnostic feature for service account

### DIFF
--- a/docs/integrations/openai/chatgpt-gpt-actions-setup.md
+++ b/docs/integrations/openai/chatgpt-gpt-actions-setup.md
@@ -77,9 +77,93 @@ paths:
                       meaning: { type: string }
                 userQuestion: { type: string }
                 reflectionsText: { type: string }
+                includePromptDebug:
+                  type: boolean
+                  default: false
+                  description: >
+                    Diagnostic opt-in. When true AND the request is
+                    authenticated as the first-party service account AND the
+                    backend has PROMPT_DEBUG_ENABLED set, the response includes a
+                    promptDebug object with the assembled system/user prompt.
+                    Ignored (silently) for any other caller.
       responses:
         '200':
           description: Reading response
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [reading]
+                properties:
+                  reading:
+                    type: string
+                    description: Generated tarot-reading narrative.
+                  provider:
+                    type: string
+                    description: Narrative provider used (e.g. openai-native, azure-gpt5, local-composer).
+                  requestId:
+                    type: string
+                    description: Unique request identifier.
+                  promptDebug:
+                    type: object
+                    description: >
+                      Present only for authorized diagnostic requests (service
+                      account + PROMPT_DEBUG_ENABLED + includePromptDebug=true).
+                      Omitted otherwise, and absent when the local composer
+                      served the reading (it uses no LLM prompt).
+                    properties:
+                      templateVersion:
+                        type: string
+                        description: Reading prompt template version (READING_PROMPT_VERSION).
+                      provider:
+                        type: string
+                        description: Backend that assembled the prompt.
+                      systemPrompt:
+                        type: string
+                        description: Verbatim system prompt sent to the narrative model.
+                      userPrompt:
+                        type: string
+                        description: Verbatim user prompt assembled from cards and context.
+```
+
+## Optional: prompt debug (`promptDebug`)
+
+For first-party diagnostics, the backend can return the exact prompt it
+assembled from the cards so the GPT can inspect it. This is **off by default**
+and gated three ways — all required:
+
+1. **Env flag** — set `PROMPT_DEBUG_ENABLED=true` (var in `wrangler.jsonc`).
+   Unset/false disables the feature entirely.
+2. **Service account** — the request must authenticate with `GPT_SERVICE_TOKEN`
+   (`auth_provider: 'service'`). API-key, session, and anonymous callers never
+   receive `promptDebug`, even with the flag on.
+3. **Opt-in** — the request body must set `includePromptDebug: true`.
+
+When all three hold, the `200` response gains a `promptDebug` object containing
+the **verbatim (unredacted)** `systemPrompt` and `userPrompt`, plus
+`templateVersion` and the assembling `provider`. Because the system prompt holds
+proprietary instructions and the user prompt can carry PII (question,
+reflections, stored memories, retrieved passages), keep the flag off in any
+environment where the service token is not exclusively owner-controlled.
+
+`promptDebug` is omitted when the reading is served by the local composer, which
+generates deterministically without an LLM prompt.
+
+Example diagnostic request:
+
+```json
+{
+  "spreadInfo": { "name": "Three Card" },
+  "cardsInfo": [
+    {
+      "position": "Past",
+      "card": "The Fool",
+      "orientation": "Upright",
+      "meaning": "New beginnings and openness"
+    }
+  ],
+  "includePromptDebug": true
+}
 ```
 
 ## Auth choice for this backend

--- a/functions/api/tarot-reading.js
+++ b/functions/api/tarot-reading.js
@@ -96,6 +96,7 @@ import {
 } from '../lib/spreadAnalysisOrchestrator.js';
 import { buildReadingReasoning } from '../lib/narrative/reasoning.js';
 import { buildSelectiveEvalGatePolicy } from '../lib/evalGatePolicy.js';
+import { getReadingPromptVersion } from '../lib/promptVersioning.js';
 
 function parseBooleanLike(value, defaultValue = false) {
   if (value === undefined || value === null) return defaultValue;
@@ -113,6 +114,65 @@ function parseMismatchRate(value, fallback = 0.5) {
   const parsed = Number.parseFloat(value);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(1, Math.max(0, parsed));
+}
+
+/**
+ * Decide whether the assembled prompt (`promptDebug`) may be returned to the
+ * caller. All three conditions are required:
+ *   1. The request opted in via `includePromptDebug: true`.
+ *   2. `PROMPT_DEBUG_ENABLED` is set on the environment (off by default).
+ *   3. The caller authenticated as the trusted first-party service account
+ *      (`auth_provider === 'service'`, i.e. presented `GPT_SERVICE_TOKEN`).
+ *
+ * The system prompt contains proprietary instructions and the user prompt can
+ * carry PII (question, reflections, stored memories, retrieved passages), so
+ * exposure is deliberately restricted to the owner's own GPT integration and is
+ * never available to anonymous or ordinary authenticated callers.
+ *
+ * @param {Object} params
+ * @param {Object} params.env - Worker environment bindings
+ * @param {Object|null} params.user - Authenticated user (from getUserFromRequest)
+ * @param {boolean} params.requested - Whether the request set includePromptDebug
+ * @returns {{ allowed: boolean, reason: string }}
+ */
+export function resolvePromptDebugAccess({ env, user, requested } = {}) {
+  if (requested !== true) {
+    return { allowed: false, reason: 'not_requested' };
+  }
+  if (!parseBooleanLike(env?.PROMPT_DEBUG_ENABLED, false)) {
+    return { allowed: false, reason: 'disabled' };
+  }
+  if (user?.auth_provider !== 'service') {
+    return { allowed: false, reason: 'unauthorized' };
+  }
+  return { allowed: true, reason: 'service' };
+}
+
+/**
+ * Build the raw prompt-debug payload from the captured prompts.
+ *
+ * Returns null when no assembled prompt exists — e.g. the local composer, which
+ * produces readings deterministically without an LLM prompt (its captured
+ * prompts are null). Prompt text is returned verbatim (unredacted) by design;
+ * access is already gated to the trusted service account by
+ * resolvePromptDebugAccess before this runs.
+ *
+ * @param {Object} params
+ * @param {{ system?: string, user?: string }|null} params.capturedPrompts
+ * @param {string|null} params.provider - Backend that produced the prompt
+ * @param {Object|null} params.promptMeta - Narrative promptMeta (for version)
+ * @returns {Object|null}
+ */
+export function buildPromptDebugPayload({ capturedPrompts, provider = null, promptMeta = null } = {}) {
+  if (!capturedPrompts || (!capturedPrompts.system && !capturedPrompts.user)) {
+    return null;
+  }
+  return {
+    templateVersion: promptMeta?.readingPromptVersion || getReadingPromptVersion(),
+    provider: provider || null,
+    systemPrompt: capturedPrompts.system || null,
+    userPrompt: capturedPrompts.user || null
+  };
 }
 
 function resolveVisionMismatchPolicy(env) {
@@ -276,7 +336,8 @@ async function finalizeReading({
   gateOverride = null,
   gateNotice = null,
   evalGateEnv = env,
-  evalGatePolicy = null
+  evalGatePolicy = null,
+  promptDebugAllowed = false
 }) {
   const originalReading = reading;
   const originalProvider = provider;
@@ -532,6 +593,21 @@ async function finalizeReading({
     ...responseGateStatus
   };
 
+  // Diagnostic: return the assembled prompt verbatim when the caller is
+  // authorized (service account + PROMPT_DEBUG_ENABLED + opt-in). Uses the
+  // original provider/prompts even when the eval gate swapped in a safe
+  // fallback, since promptDebug describes what was actually assembled and sent.
+  if (promptDebugAllowed) {
+    const promptDebug = buildPromptDebugPayload({
+      capturedPrompts,
+      provider: originalProvider,
+      promptMeta
+    });
+    if (promptDebug) {
+      responsePayload.promptDebug = promptDebug;
+    }
+  }
+
   return {
     responsePayload,
     evalGateResult,
@@ -596,7 +672,8 @@ export const onRequestPost = async ({ request, env, waitUntil }) => {
       deckStyle: requestDeckStyle,
       personalization: requestPersonalization,
       location: rawLocation,
-      persistLocationToJournal: _persistLocationToJournal // Used by journal endpoint, not reading
+      persistLocationToJournal: _persistLocationToJournal, // Used by journal endpoint, not reading
+      includePromptDebug
     } = normalizedPayload;
     const deckStyle = requestDeckStyle || spreadInfo?.deckStyle || 'rws-1909';
     const cardsInfo = rawCardsInfo.map((card) => {
@@ -666,6 +743,18 @@ export const onRequestPost = async ({ request, env, waitUntil }) => {
     const user = await getUserFromRequest(request, env);
     const subscription = getSubscriptionContext(user);
     const subscriptionTier = subscription.effectiveTier;
+
+    // Resolve prompt-debug access once: only the trusted service account may
+    // receive the assembled prompt back, and only when PROMPT_DEBUG_ENABLED is
+    // set and the request opted in. See resolvePromptDebugAccess.
+    const promptDebugAccess = resolvePromptDebugAccess({
+      env,
+      user,
+      requested: includePromptDebug === true
+    });
+    if (includePromptDebug === true && !promptDebugAccess.allowed) {
+      console.log(`[${requestId}] promptDebug requested but not granted (${promptDebugAccess.reason})`);
+    }
 
     const {
       personalization,
@@ -1177,7 +1266,8 @@ Your cards will be here when you're ready. Right now, please take care of yourse
               allowGateBlocking: true,
               gateOverride,
               evalGateEnv,
-              evalGatePolicy
+              evalGatePolicy,
+              promptDebugAllowed: promptDebugAccess.allowed
             });
 
             if (attemptAssignment) {
@@ -1202,6 +1292,14 @@ Your cards will be here when you're ready. Right now, please take care of yourse
             : contextDiagnostics;
           const emotionalTone = deriveEmotionalTone(analysis.themes);
 
+          const streamPromptDebug = promptDebugAccess.allowed
+            ? buildPromptDebugPayload({
+              capturedPrompts,
+              provider: streamProvider,
+              promptMeta: narrativePayload.promptMeta
+            })
+            : null;
+
           const streamMeta = {
             requestId,
             provider: streamProvider,
@@ -1216,7 +1314,8 @@ Your cards will be here when you're ready. Right now, please take care of yourse
             spreadAnalysis: buildSpreadAnalysisPayload(analysis),
             gateBlocked: false,
             gateReason: null,
-            backendErrors: null
+            backendErrors: null,
+            ...(streamPromptDebug ? { promptDebug: streamPromptDebug } : {})
           };
 
           const wrappedStream = wrapReadingStreamWithMetadata(transformedStream, {
@@ -1256,7 +1355,8 @@ Your cards will be here when you're ready. Right now, please take care of yourse
                 acceptedQualityMetrics: null,
                 allowGateBlocking: false,
                 evalGateEnv,
-                evalGatePolicy
+                evalGatePolicy,
+                promptDebugAllowed: promptDebugAccess.allowed
               });
               if (attemptAssignment) {
                 console.log(`[${requestId}] A/B assignment accepted: ${attemptAssignment.experimentId} → ${attemptAssignment.variantId} (provider: ${streamProvider})`);
@@ -1464,7 +1564,8 @@ Your cards will be here when you're ready. Right now, please take care of yourse
       allowGateBlocking: true,
       gateOverride,
       evalGateEnv,
-      evalGatePolicy
+      evalGatePolicy,
+      promptDebugAllowed: promptDebugAccess.allowed
     });
 
     if (useStreaming) {

--- a/shared/contracts/readingSchema.js
+++ b/shared/contracts/readingSchema.js
@@ -105,7 +105,12 @@ export const readingRequestSchema = z.object({
   visionProof: optionalVisionProofSchema.optional(),
   personalization: personalizationSchema.optional(),
   location: locationSchema,
-  persistLocationToJournal: z.boolean().optional()
+  persistLocationToJournal: z.boolean().optional(),
+  // Opt-in diagnostic flag: request the assembled system/user prompt back in
+  // the response. Only honored for the trusted first-party service account and
+  // when PROMPT_DEBUG_ENABLED is set (see resolvePromptDebugAccess in
+  // functions/api/tarot-reading.js). Ignored otherwise.
+  includePromptDebug: z.boolean().optional()
 });
 
 export const readingResponseSchema = z.object({

--- a/tarot-reading-openapi.yaml
+++ b/tarot-reading-openapi.yaml
@@ -217,6 +217,15 @@ components:
         persistLocationToJournal:
           type: boolean
           description: Whether to persist location data with the journal entry.
+        includePromptDebug:
+          type: boolean
+          default: false
+          description: >
+            Diagnostic opt-in. When true AND the request is authenticated as
+            the service account (GPT_SERVICE_TOKEN) AND the backend has
+            PROMPT_DEBUG_ENABLED set, the response includes a `promptDebug`
+            object with the verbatim assembled system/user prompt. Ignored
+            (silently) for any other caller.
     DrawTarotReadingRequest:
       type: object
       required:
@@ -265,6 +274,15 @@ components:
         persistLocationToJournal:
           type: boolean
           description: Whether to persist location data with the journal entry.
+        includePromptDebug:
+          type: boolean
+          default: false
+          description: >
+            Diagnostic opt-in. When true AND the request is authenticated as
+            the service account (GPT_SERVICE_TOKEN) AND the backend has
+            PROMPT_DEBUG_ENABLED set, the response includes a `promptDebug`
+            object with the verbatim assembled system/user prompt. Ignored
+            (silently) for any other caller.
     DrawTarotReadingResponse:
       type: object
       required:
@@ -339,6 +357,8 @@ components:
             - type: object
               additionalProperties: true
             - type: "null"
+        promptDebug:
+          $ref: "#/components/schemas/PromptDebug"
     SpreadInfo:
       type: object
       required:
@@ -542,6 +562,34 @@ components:
             - type: object
               additionalProperties: true
             - type: "null"
+        promptDebug:
+          $ref: "#/components/schemas/PromptDebug"
+    PromptDebug:
+      type: object
+      additionalProperties: true
+      description: >
+        Diagnostic echo of the exact prompt the backend assembled for the
+        narrative model. Present only when the request set
+        `includePromptDebug: true`, the caller authenticated as the service
+        account, and the backend has `PROMPT_DEBUG_ENABLED` set. Absent for
+        readings served by the local composer, which uses no model prompt.
+        The prompt text is returned verbatim (unredacted).
+      properties:
+        templateVersion:
+          type: string
+          description: Reading prompt template version (READING_PROMPT_VERSION).
+        provider:
+          type: string
+          description: Narrative backend that assembled the prompt.
+          examples:
+            - openai-native
+            - azure-gpt5
+        systemPrompt:
+          type: string
+          description: Verbatim system prompt sent to the narrative model.
+        userPrompt:
+          type: string
+          description: Verbatim user prompt assembled from the cards and context.
     ErrorResponse:
       type: object
       additionalProperties: true

--- a/tests/promptDebug.test.mjs
+++ b/tests/promptDebug.test.mjs
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  onRequestPost,
+  resolvePromptDebugAccess,
+  buildPromptDebugPayload
+} from '../functions/api/tarot-reading.js';
+import { safeParseReadingRequest } from '../shared/contracts/readingSchema.js';
+import { READING_PROMPT_VERSION } from '../functions/lib/promptVersioning.js';
+
+// A 24+ char token so isServiceAuthConfigured accepts it (MIN_SERVICE_TOKEN_LENGTH).
+const SERVICE_TOKEN = 'svc-tok-0123456789abcdef012345';
+
+const SINGLE_CARD_PAYLOAD = {
+  spreadInfo: { name: 'One-Card Insight' },
+  cardsInfo: [
+    {
+      position: 'One-Card Insight',
+      card: 'The Fool',
+      orientation: 'Upright',
+      meaning: 'New beginnings'
+    }
+  ],
+  reflectionsText: ''
+};
+
+// English narrative mentioning the drawn card so the quality gate accepts it.
+const MOCK_READING = [
+  '### Opening',
+  '',
+  '**The Fool** marks a fresh threshold for you.',
+  '',
+  '### Guidance',
+  '',
+  'Move with curiosity and one clear step at a time.',
+  '',
+  '- Trust your first impulse.',
+  '- Choose one small action today.',
+  '',
+  '### Closing',
+  '',
+  'Your path clarifies as you move forward.'
+].join('\n');
+
+function makeRequest(payload, { authorization } = {}) {
+  const headers = { 'content-type': 'application/json' };
+  if (authorization) headers.authorization = authorization;
+  return new Request('http://localhost/api/tarot-reading', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function withMockedFetch(mockFetch, fn) {
+  const originalFetch = global.fetch;
+  global.fetch = mockFetch;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+function mockAzureFetch() {
+  return async () => new Response(
+    JSON.stringify({
+      output_text: MOCK_READING,
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 }
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  );
+}
+
+const AZURE_ENV = {
+  AZURE_OPENAI_API_KEY: 'test-key',
+  AZURE_OPENAI_ENDPOINT: 'https://example.com',
+  AZURE_OPENAI_GPT5_MODEL: 'gpt-5',
+  EVAL_ENABLED: 'false',
+  EVAL_GATE_ENABLED: 'false',
+  GRAPHRAG_ENABLED: 'false'
+};
+
+// ---------------------------------------------------------------------------
+// Unit: resolvePromptDebugAccess gate
+// ---------------------------------------------------------------------------
+
+describe('resolvePromptDebugAccess', () => {
+  const serviceUser = { auth_provider: 'service' };
+  const enabledEnv = { PROMPT_DEBUG_ENABLED: 'true' };
+
+  it('denies when the request did not opt in', () => {
+    const result = resolvePromptDebugAccess({ env: enabledEnv, user: serviceUser, requested: false });
+    assert.equal(result.allowed, false);
+    assert.equal(result.reason, 'not_requested');
+  });
+
+  it('denies when the env flag is off (even for the service account)', () => {
+    const result = resolvePromptDebugAccess({ env: {}, user: serviceUser, requested: true });
+    assert.equal(result.allowed, false);
+    assert.equal(result.reason, 'disabled');
+  });
+
+  it('denies anonymous callers when enabled + requested', () => {
+    const result = resolvePromptDebugAccess({ env: enabledEnv, user: null, requested: true });
+    assert.equal(result.allowed, false);
+    assert.equal(result.reason, 'unauthorized');
+  });
+
+  it('denies API-key and session callers when enabled + requested', () => {
+    for (const provider of ['api_key', 'session']) {
+      const result = resolvePromptDebugAccess({
+        env: enabledEnv,
+        user: { auth_provider: provider },
+        requested: true
+      });
+      assert.equal(result.allowed, false, `${provider} should be denied`);
+      assert.equal(result.reason, 'unauthorized');
+    }
+  });
+
+  it('allows only the service account with flag on and opt-in', () => {
+    const result = resolvePromptDebugAccess({ env: enabledEnv, user: serviceUser, requested: true });
+    assert.equal(result.allowed, true);
+    assert.equal(result.reason, 'service');
+  });
+
+  it('accepts truthy string forms of the flag', () => {
+    for (const value of ['true', '1', 'yes', 'on']) {
+      const result = resolvePromptDebugAccess({
+        env: { PROMPT_DEBUG_ENABLED: value },
+        user: serviceUser,
+        requested: true
+      });
+      assert.equal(result.allowed, true, `flag="${value}" should enable`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: buildPromptDebugPayload
+// ---------------------------------------------------------------------------
+
+describe('buildPromptDebugPayload', () => {
+  it('returns null when there are no captured prompts (e.g. local composer)', () => {
+    assert.equal(buildPromptDebugPayload({ capturedPrompts: null }), null);
+    assert.equal(buildPromptDebugPayload({ capturedPrompts: { system: '', user: '' } }), null);
+    assert.equal(buildPromptDebugPayload({}), null);
+  });
+
+  it('returns raw prompts verbatim with provider and version', () => {
+    const payload = buildPromptDebugPayload({
+      capturedPrompts: { system: 'SYS-PROMPT', user: 'USER-PROMPT' },
+      provider: 'azure-gpt5'
+    });
+    assert.equal(payload.systemPrompt, 'SYS-PROMPT');
+    assert.equal(payload.userPrompt, 'USER-PROMPT');
+    assert.equal(payload.provider, 'azure-gpt5');
+    assert.equal(payload.templateVersion, READING_PROMPT_VERSION);
+  });
+
+  it('prefers promptMeta.readingPromptVersion when present', () => {
+    const payload = buildPromptDebugPayload({
+      capturedPrompts: { system: 'S', user: 'U' },
+      promptMeta: { readingPromptVersion: '9.9.9' }
+    });
+    assert.equal(payload.templateVersion, '9.9.9');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema: includePromptDebug round-trips through the request contract
+// ---------------------------------------------------------------------------
+
+describe('readingRequestSchema includePromptDebug', () => {
+  it('accepts includePromptDebug boolean', () => {
+    const result = safeParseReadingRequest({ ...SINGLE_CARD_PAYLOAD, includePromptDebug: true });
+    assert.equal(result.success, true, result.error);
+    assert.equal(result.data.includePromptDebug, true);
+  });
+
+  it('omits the field when not provided', () => {
+    const result = safeParseReadingRequest({ ...SINGLE_CARD_PAYLOAD });
+    assert.equal(result.success, true, result.error);
+    assert.equal(result.data.includePromptDebug, undefined);
+  });
+
+  it('rejects a non-boolean includePromptDebug', () => {
+    const result = safeParseReadingRequest({ ...SINGLE_CARD_PAYLOAD, includePromptDebug: 'yes' });
+    assert.equal(result.success, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: end-to-end promptDebug behavior through onRequestPost
+// ---------------------------------------------------------------------------
+
+describe('tarot-reading promptDebug response', () => {
+  it('returns the verbatim assembled prompt for the service account when enabled + opted in', async () => {
+    const request = makeRequest(
+      {
+        ...SINGLE_CARD_PAYLOAD,
+        userQuestion: 'How can I support my friend Zephyrina?',
+        includePromptDebug: true
+      },
+      { authorization: `Bearer ${SERVICE_TOKEN}` }
+    );
+    const env = {
+      ...AZURE_ENV,
+      PROMPT_DEBUG_ENABLED: 'true',
+      GPT_SERVICE_TOKEN: SERVICE_TOKEN
+    };
+
+    await withMockedFetch(mockAzureFetch(), async () => {
+      const response = await onRequestPost({ request, env });
+      assert.equal(response.status, 200);
+
+      const payload = await response.json();
+      assert.equal(payload.provider, 'azure-gpt5');
+      assert.ok(payload.promptDebug, 'promptDebug should be present');
+      assert.equal(payload.promptDebug.provider, 'azure-gpt5');
+      assert.equal(payload.promptDebug.templateVersion, READING_PROMPT_VERSION);
+      assert.ok(
+        typeof payload.promptDebug.systemPrompt === 'string' && payload.promptDebug.systemPrompt.length > 0,
+        'systemPrompt should be a non-empty string'
+      );
+      // The user prompt is the real assembled prompt: it references the drawn
+      // card and echoes the raw (unredacted) question.
+      assert.match(payload.promptDebug.userPrompt, /Fool/);
+      assert.match(payload.promptDebug.userPrompt, /Zephyrina/);
+    });
+  });
+
+  it('omits promptDebug when the request did not opt in', async () => {
+    const request = makeRequest(
+      { ...SINGLE_CARD_PAYLOAD, userQuestion: 'How can I move forward?' },
+      { authorization: `Bearer ${SERVICE_TOKEN}` }
+    );
+    const env = {
+      ...AZURE_ENV,
+      PROMPT_DEBUG_ENABLED: 'true',
+      GPT_SERVICE_TOKEN: SERVICE_TOKEN
+    };
+
+    await withMockedFetch(mockAzureFetch(), async () => {
+      const response = await onRequestPost({ request, env });
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.equal(payload.provider, 'azure-gpt5');
+      assert.equal(payload.promptDebug, undefined);
+    });
+  });
+
+  it('omits promptDebug when PROMPT_DEBUG_ENABLED is off', async () => {
+    const request = makeRequest(
+      { ...SINGLE_CARD_PAYLOAD, userQuestion: 'How can I move forward?', includePromptDebug: true },
+      { authorization: `Bearer ${SERVICE_TOKEN}` }
+    );
+    const env = {
+      ...AZURE_ENV,
+      GPT_SERVICE_TOKEN: SERVICE_TOKEN
+      // PROMPT_DEBUG_ENABLED intentionally unset
+    };
+
+    await withMockedFetch(mockAzureFetch(), async () => {
+      const response = await onRequestPost({ request, env });
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.equal(payload.promptDebug, undefined);
+    });
+  });
+
+  it('omits promptDebug for non-service (anonymous) callers even when enabled + opted in', async () => {
+    const request = makeRequest({
+      ...SINGLE_CARD_PAYLOAD,
+      userQuestion: 'How can I move forward?',
+      includePromptDebug: true
+    });
+    const env = {
+      ...AZURE_ENV,
+      PROMPT_DEBUG_ENABLED: 'true'
+      // No GPT_SERVICE_TOKEN and no auth header -> anonymous caller.
+    };
+
+    await withMockedFetch(mockAzureFetch(), async () => {
+      const response = await onRequestPost({ request, env });
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.equal(payload.promptDebug, undefined);
+    });
+  });
+
+  it('omits promptDebug for the local composer (no LLM prompt) even when authorized', async () => {
+    const request = makeRequest(
+      { ...SINGLE_CARD_PAYLOAD, userQuestion: 'How can I move forward?', includePromptDebug: true },
+      { authorization: `Bearer ${SERVICE_TOKEN}` }
+    );
+    // No AI backend configured -> local-composer serves the reading.
+    const env = {
+      PROMPT_DEBUG_ENABLED: 'true',
+      GPT_SERVICE_TOKEN: SERVICE_TOKEN
+    };
+
+    const response = await onRequestPost({ request, env });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.provider, 'local-composer');
+    assert.equal(payload.promptDebug, undefined);
+  });
+});

--- a/tests/promptDebug.test.mjs
+++ b/tests/promptDebug.test.mjs
@@ -6,8 +6,11 @@ import {
   resolvePromptDebugAccess,
   buildPromptDebugPayload
 } from '../functions/api/tarot-reading.js';
+import { onRequestPost as drawTarotReading } from '../functions/api/tarot-reading-draw.js';
 import { safeParseReadingRequest } from '../shared/contracts/readingSchema.js';
 import { READING_PROMPT_VERSION } from '../functions/lib/promptVersioning.js';
+import { drawSpread } from '../src/lib/deck.js';
+import { hashString } from '../shared/utils.js';
 
 // A 24+ char token so isServiceAuthConfigured accepts it (MIN_SERVICE_TOKEN_LENGTH).
 const SERVICE_TOKEN = 'svc-tok-0123456789abcdef012345';
@@ -67,6 +70,31 @@ function mockAzureFetch() {
   return async () => new Response(
     JSON.stringify({
       output_text: MOCK_READING,
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 }
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  );
+}
+
+// Build a mock narrative that names the given cards, so a backend-drawn hand
+// clears the card-coverage quality gate and the azure-gpt5 backend is accepted.
+function mockAzureFetchCovering(cardNames) {
+  const body = [
+    '### Opening',
+    '',
+    ...cardNames.map((name) => `**${name}** speaks to a fresh threshold for you.`),
+    '',
+    '### Guidance',
+    '',
+    'Move with curiosity and one clear step at a time.',
+    '',
+    '### Closing',
+    '',
+    'Your path clarifies as you move forward.'
+  ].join('\n');
+  return async () => new Response(
+    JSON.stringify({
+      output_text: body,
       usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 }
     }),
     { status: 200, headers: { 'content-type': 'application/json' } }
@@ -307,5 +335,68 @@ describe('tarot-reading promptDebug response', () => {
     const payload = await response.json();
     assert.equal(payload.provider, 'local-composer');
     assert.equal(payload.promptDebug, undefined);
+  });
+});
+
+describe('drawTarotReading promptDebug passthrough', () => {
+  it('forwards includePromptDebug and preserves promptDebug for the service account', async () => {
+    // The draw handler forwards the whole payload (incl. includePromptDebug)
+    // and the original auth header to the /api/tarot-reading pipeline, then
+    // spreads the inner response back out — so promptDebug must survive.
+    const seedStr = 'promptdebug-draw-seed';
+    const seed = (hashString(seedStr) >>> 0) || 0x9e3779b9; // mirror coerceSeed
+    const drawn = drawSpread({ spreadKey: 'single', useSeed: true, seed, includeMinors: true });
+    const cardNames = drawn.map((c) => c.name);
+
+    const request = makeRequest(
+      {
+        spreadInfo: { name: 'One-Card Insight', key: 'single' },
+        userQuestion: 'How can I support my friend Zephyrina?',
+        allowReversals: false,
+        seed: seedStr,
+        includePromptDebug: true
+      },
+      { authorization: `Bearer ${SERVICE_TOKEN}` }
+    );
+    const env = {
+      ...AZURE_ENV,
+      PROMPT_DEBUG_ENABLED: 'true',
+      GPT_SERVICE_TOKEN: SERVICE_TOKEN
+    };
+
+    await withMockedFetch(mockAzureFetchCovering(cardNames), async () => {
+      const response = await drawTarotReading({ request, env });
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.ok(Array.isArray(payload.cardsInfo) && payload.cardsInfo.length === 1);
+      assert.equal(payload.provider, 'azure-gpt5');
+      assert.ok(payload.promptDebug, 'draw response should carry promptDebug');
+      assert.equal(payload.promptDebug.provider, 'azure-gpt5');
+      assert.match(payload.promptDebug.userPrompt, /Zephyrina/);
+    });
+  });
+
+  it('omits promptDebug on the draw path for anonymous callers', async () => {
+    const seedStr = 'promptdebug-draw-seed-anon';
+    const seed = (hashString(seedStr) >>> 0) || 0x9e3779b9;
+    const drawn = drawSpread({ spreadKey: 'single', useSeed: true, seed, includeMinors: true });
+    const cardNames = drawn.map((c) => c.name);
+
+    const request = makeRequest({
+      spreadInfo: { name: 'One-Card Insight', key: 'single' },
+      userQuestion: 'How can I move forward?',
+      allowReversals: false,
+      seed: seedStr,
+      includePromptDebug: true
+    });
+    const env = { ...AZURE_ENV, PROMPT_DEBUG_ENABLED: 'true' }; // no service token
+
+    await withMockedFetch(mockAzureFetchCovering(cardNames), async () => {
+      const response = await drawTarotReading({ request, env });
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.equal(payload.provider, 'azure-gpt5');
+      assert.equal(payload.promptDebug, undefined);
+    });
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -102,6 +102,12 @@
     "LOG_ENHANCEMENT_TELEMETRY": "true",
     "PERSIST_PROMPTS": "false",
     "SKIP_PII_REDACTION": "false",
+    // PROMPT_DEBUG_ENABLED: when "true", the /api/tarot-reading response may
+    // return the verbatim assembled prompt as `promptDebug`. Additionally gated
+    // on the caller being the GPT service account (GPT_SERVICE_TOKEN) and the
+    // request setting includePromptDebug=true. Keep "false" in production unless
+    // the service token is exclusively owner-controlled.
+    "PROMPT_DEBUG_ENABLED": "false",
     "ENABLE_TTS_DEBUG_LOGGING": "false",
     "ENABLE_SPEECH_TOKEN_DEBUG": "false",
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an optional diagnostic feature that allows the first-party service account to request and receive the exact system and user prompts assembled by the backend for the narrative model. This enables debugging and validation of prompt construction without exposing sensitive prompt details to regular users.

## Key Changes

- **Access Control** (`resolvePromptDebugAccess`): Three-way gate requiring all of:
  1. Request opt-in via `includePromptDebug: true`
  2. Environment flag `PROMPT_DEBUG_ENABLED=true`
  3. Caller authenticated as service account (`auth_provider === 'service'`)

- **Payload Builder** (`buildPromptDebugPayload`): Constructs diagnostic object with verbatim `systemPrompt`, `userPrompt`, `provider`, and `templateVersion`. Returns null for local composer (no LLM prompt).

- **Request Schema**: Added optional `includePromptDebug: boolean` field to `readingRequestSchema` in `shared/contracts/readingSchema.js`.

- **Response Integration**: 
  - Main `/api/tarot-reading` endpoint includes `promptDebug` in response when authorized
  - Streaming responses include `promptDebug` in metadata
  - `/api/tarot-reading-draw` forwards `includePromptDebug` and preserves `promptDebug` in passthrough

- **Documentation**:
  - Updated OpenAPI schema (`tarot-reading-openapi.yaml`) with `PromptDebug` component and request/response examples
  - Added setup guide section in ChatGPT integration docs explaining the feature, security model, and example usage
  - Added `PROMPT_DEBUG_ENABLED` environment variable documentation in `wrangler.jsonc`

- **Test Coverage** (`tests/promptDebug.test.mjs`): 402 lines of comprehensive tests covering:
  - Access control gate logic (disabled, unauthorized, service-only)
  - Payload builder (null for local composer, verbatim prompts with metadata)
  - Schema validation (boolean type, optional field)
  - End-to-end integration (service account receives prompts, others don't)
  - Draw endpoint passthrough behavior

## Implementation Details

- Prompts are returned **verbatim and unredacted** by design; access is already restricted to the trusted service account
- Feature is **off by default** and requires explicit environment configuration
- Works with both streaming and non-streaming response paths
- Gracefully omitted when local composer serves the reading (no assembled prompt exists)
- Diagnostic logging when `includePromptDebug` is requested but not granted

https://claude.ai/code/session_01AHhmhjzYvw5eCoEXzvxawr