### PR TITLE
Card draw/reveal remediation: workstreams 1-5

### DIFF
--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -18,7 +18,9 @@ const CARD_WIDTH_FLOORS = {
     threeCard: 63,
     fiveCard: 44,
     decision: 63,
-    relationship: 41
+    relationship: 41,
+    // Compact handset Celtic fits a square board six card-heights tall.
+    celtic: 55
   },
   768: {
     single: 127,
@@ -100,13 +102,43 @@ const SPREADS = [
       { x: 82, y: 62.67 },
       { x: 82, y: 37.33 },
       { x: 82, y: 12 }
-    ]
+    ],
+    // Handsets substitute the compact plus-over-staff layout; every other
+    // viewport keeps the desktop geometry above.
+    positionsByViewportWidth: {
+      390: [
+        { x: 50, y: 37.5 },
+        { x: 50, y: 37.5, challengeOffset: true },
+        { x: 22, y: 37.5 },
+        { x: 78, y: 37.5 },
+        { x: 50, y: 12.5 },
+        { x: 50, y: 62.5 },
+        { x: 12.5, y: 87.5 },
+        { x: 37.5, y: 87.5 },
+        { x: 62.5, y: 87.5 },
+        { x: 87.5, y: 87.5 }
+      ]
+    }
   }
 ];
+
+function getExpectedPositions(spread, viewportWidth) {
+  return spread.positionsByViewportWidth?.[viewportWidth] || spread.positions;
+}
+
+function boxOverlap(left, right) {
+  return {
+    width: Math.min(left.x + left.width, right.x + right.width) - Math.max(left.x, right.x),
+    height: Math.min(left.y + left.height, right.y + right.height) - Math.max(left.y, right.y)
+  };
+}
 
 function seedReadingUi(page) {
   return page.addInitScript(() => {
     localStorage.setItem('tarot-onboarding-complete', 'true');
+    // Suppress the Tactile Lens micro-tutorial; its pulse animation would
+    // resize the button mid-measurement.
+    localStorage.setItem('tableu_lens_tutorial_shown', 'true');
     localStorage.setItem('tarot-nudge-state', JSON.stringify({
       readingCount: 1,
       hasSeenRitualNudge: true,
@@ -176,14 +208,11 @@ async function expectLayoutGeometry(page, spreadKey, positions, challengeOffsetP
   for (let leftIndex = 0; leftIndex < cardBoxes.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < cardBoxes.length; rightIndex += 1) {
       if (spreadKey === 'celtic' && leftIndex === 0 && rightIndex === 1) continue;
-      const left = cardBoxes[leftIndex];
-      const right = cardBoxes[rightIndex];
-      const overlapWidth = Math.min(left.x + left.width, right.x + right.width) - Math.max(left.x, right.x);
-      const overlapHeight = Math.min(left.y + left.height, right.y + right.height) - Math.max(left.y, right.y);
+      const overlap = boxOverlap(cardBoxes[leftIndex], cardBoxes[rightIndex]);
 
       expect(
-        overlapWidth <= 1 || overlapHeight <= 1,
-        `${spreadKey} slots ${leftIndex}/${rightIndex} overlap by ${overlapWidth.toFixed(2)}x${overlapHeight.toFixed(2)}px`
+        overlap.width <= 1 || overlap.height <= 1,
+        `${spreadKey} slots ${leftIndex}/${rightIndex} overlap by ${overlap.width.toFixed(2)}x${overlap.height.toFixed(2)}px`
       ).toBe(true);
     }
   }
@@ -205,13 +234,144 @@ for (const viewport of VIEWPORTS) {
       await expectLayoutGeometry(
         page,
         spread.key,
-        spread.positions,
+        getExpectedPositions(spread, viewport.width),
         CELTIC_CHALLENGE_OFFSET_BY_VIEWPORT[viewport.width] || 0,
         CARD_WIDTH_FLOORS[viewport.width][spread.key]
       );
     }
   });
 }
+
+test('keeps handset Celtic board controls clear of the card field', async ({ page }) => {
+  await page.setViewportSize(VIEWPORTS[0]);
+  await seedReadingUi(page);
+  await openSpread(page, 'celtic', 10);
+
+  const controlBoxes = {
+    'tactile lens': await page.getByRole('button', { name: 'Position meanings' }).boundingBox(),
+    reset: await page.getByRole('button', { name: /reset reveals/i }).boundingBox()
+  };
+
+  for (const [name, box] of Object.entries(controlBoxes)) {
+    expect(box, `${name} control must be rendered`).not.toBeNull();
+  }
+
+  for (let index = 0; index < 10; index += 1) {
+    const cardBox = await page.locator(`[data-slot-index="${index}"] [data-layout-card]`).boundingBox();
+    expect(cardBox).not.toBeNull();
+
+    for (const [name, controlBox] of Object.entries(controlBoxes)) {
+      const overlap = boxOverlap(controlBox, cardBox);
+      expect(
+        overlap.width <= 1 || overlap.height <= 1,
+        `${name} control overlaps card ${index} by ${overlap.width.toFixed(2)}x${overlap.height.toFixed(2)}px`
+      ).toBe(true);
+    }
+  }
+
+  const controlOverlap = boxOverlap(controlBoxes['tactile lens'], controlBoxes.reset);
+  expect(
+    controlOverlap.width <= 1 || controlOverlap.height <= 1,
+    `tactile lens overlaps reset by ${controlOverlap.width.toFixed(2)}x${controlOverlap.height.toFixed(2)}px`
+  ).toBe(true);
+
+  await expect(page.getByRole('button', { name: 'Position meanings' })).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('grows compact Celtic cards to the board on a wide handset', async ({ page }) => {
+  await page.setViewportSize({ width: 600, height: 900 });
+  await seedReadingUi(page);
+  await openSpread(page, 'celtic', 10);
+
+  const table = page.locator('[role="region"][aria-label$="layout"]');
+  const tableBox = await table.boundingBox();
+  const cardBoxes = [];
+  const logicalCardWidths = [];
+
+  for (let index = 0; index < 10; index += 1) {
+    const card = page.locator(`[data-slot-index="${index}"] [data-layout-card]`);
+    const cardBox = await card.boundingBox();
+    expect(cardBox).not.toBeNull();
+
+    expect(cardBox.x, `slot ${index} left edge`).toBeGreaterThanOrEqual(tableBox.x - 1);
+    expect(cardBox.y, `slot ${index} top edge`).toBeGreaterThanOrEqual(tableBox.y - 1);
+    expect(cardBox.x + cardBox.width, `slot ${index} right edge`).toBeLessThanOrEqual(tableBox.x + tableBox.width + 1);
+    expect(cardBox.y + cardBox.height, `slot ${index} bottom edge`).toBeLessThanOrEqual(tableBox.y + tableBox.height + 1);
+
+    cardBoxes.push(cardBox);
+    logicalCardWidths.push(await card.evaluate((element) => Number.parseFloat(getComputedStyle(element).width)));
+  }
+
+  for (let leftIndex = 0; leftIndex < cardBoxes.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < cardBoxes.length; rightIndex += 1) {
+      if (leftIndex === 0 && rightIndex === 1) continue;
+      const overlap = boxOverlap(cardBoxes[leftIndex], cardBoxes[rightIndex]);
+      expect(
+        overlap.width <= 1 || overlap.height <= 1,
+        `celtic slots ${leftIndex}/${rightIndex} overlap by ${overlap.width.toFixed(2)}x${overlap.height.toFixed(2)}px`
+      ).toBe(true);
+    }
+  }
+
+  // The board, not a fixed size class, must set the card size across the whole
+  // handset range: a 544px board fits cards a sixth of its height.
+  expect(Math.min(...logicalCardWidths), 'wide handset celtic card width floor').toBeGreaterThanOrEqual(88);
+});
+
+test('anchors handset Celtic orientation overlays to the compact coordinates', async ({ page }) => {
+  const compactPositions = SPREADS.find((spread) => spread.key === 'celtic').positionsByViewportWidth[390];
+  // Self/Advice moves from the desktop staff column (82%, 88%) to the compact
+  // staff row, so it separates live coordinates from stale ones.
+  const adviceIndex = 6;
+  const advice = compactPositions[adviceIndex];
+
+  await page.setViewportSize(VIEWPORTS[0]);
+  await seedReadingUi(page);
+  await openSpread(page, 'celtic', 10);
+
+  const expectCentredAt = async (marker, container, position, label) => {
+    const markerBox = await marker.boundingBox();
+    const containerBox = await container.boundingBox();
+    expect(markerBox, `${label} marker must be rendered`).not.toBeNull();
+
+    const actualX = markerBox.x + (markerBox.width / 2);
+    const actualY = markerBox.y + (markerBox.height / 2);
+    const expectedX = containerBox.x + (containerBox.width * (position.x / 100));
+    const expectedY = containerBox.y + (containerBox.height * (position.y / 100));
+
+    expect(Math.abs(actualX - expectedX), `${label} horizontal centre`).toBeLessThanOrEqual(2);
+    expect(Math.abs(actualY - expectedY), `${label} vertical centre`).toBeLessThanOrEqual(2);
+  };
+
+  const lensButton = page.getByRole('button', { name: 'Position meanings' });
+  const lensButtonBox = await lensButton.boundingBox();
+  await page.mouse.move(
+    lensButtonBox.x + (lensButtonBox.width / 2),
+    lensButtonBox.y + (lensButtonBox.height / 2)
+  );
+  await page.mouse.down();
+
+  const lensOverlay = page.getByRole('region', { name: 'Position meanings' });
+  await expect(lensOverlay).toBeVisible();
+  await expectCentredAt(
+    lensOverlay.getByText('Self / Advice — how to meet this').locator('xpath=../..'),
+    page.locator('[role="region"][aria-label$="layout"]'),
+    advice,
+    'tactile lens Self/Advice'
+  );
+  await page.mouse.up();
+  await expect(lensOverlay).toBeHidden();
+
+  await page.getByRole('button', { name: 'Show Celtic Cross position map' }).click();
+  const mapOverlay = page.getByRole('dialog', { name: 'Celtic Cross position map' });
+  await expect(mapOverlay).toBeVisible();
+  await expectCentredAt(
+    mapOverlay.getByText('Advice', { exact: true }).locator('xpath=..'),
+    mapOverlay,
+    advice,
+    'position map Advice'
+  );
+});
 
 test('keeps a narrative mention pulse visible beyond the revealed card border', async ({ page }) => {
   await page.setViewportSize(VIEWPORTS[2]);

--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -8,8 +8,34 @@ const VIEWPORTS = [
 
 const CELTIC_CHALLENGE_OFFSET_BY_VIEWPORT = {
   390: 18,
-  768: 32.725,
-  1280: 43.990625
+  768: 22.32,
+  1280: 30.72
+};
+
+const CARD_WIDTH_FLOORS = {
+  390: {
+    single: 63,
+    threeCard: 63,
+    fiveCard: 44,
+    decision: 63,
+    relationship: 41
+  },
+  768: {
+    single: 127,
+    threeCard: 127,
+    fiveCard: 99,
+    decision: 127,
+    relationship: 92,
+    celtic: 99
+  },
+  1280: {
+    single: 127,
+    threeCard: 127,
+    fiveCard: 127,
+    decision: 127,
+    relationship: 127,
+    celtic: 127
+  }
 };
 
 const SPREADS = [
@@ -42,11 +68,11 @@ const SPREADS = [
     key: 'decision',
     name: 'Decision',
     positions: [
-      { x: 50, y: 20 },
-      { x: 25, y: 50 },
-      { x: 75, y: 50 },
-      { x: 50, y: 70 },
-      { x: 50, y: 80 }
+      { x: 50, y: 22 },
+      { x: 20, y: 50 },
+      { x: 80, y: 50 },
+      { x: 40, y: 78 },
+      { x: 60, y: 78 }
     ]
   },
   {
@@ -66,14 +92,14 @@ const SPREADS = [
     positions: [
       { x: 35, y: 50 },
       { x: 35, y: 50, challengeOffset: true },
-      { x: 15, y: 50 },
-      { x: 55, y: 50 },
-      { x: 35, y: 20 },
-      { x: 35, y: 80 },
-      { x: 80, y: 80 },
-      { x: 80, y: 60 },
-      { x: 80, y: 40 },
-      { x: 80, y: 20 }
+      { x: 12, y: 50 },
+      { x: 58, y: 50 },
+      { x: 35, y: 12 },
+      { x: 35, y: 88 },
+      { x: 82, y: 88 },
+      { x: 82, y: 62.67 },
+      { x: 82, y: 37.33 },
+      { x: 82, y: 12 }
     ]
   }
 ];
@@ -104,7 +130,7 @@ async function openSpread(page, spreadKey, expectedCardCount) {
   await expect(page.locator('[data-slot-index] [data-layout-card]')).toHaveCount(expectedCardCount, { timeout: 10000 });
 }
 
-async function expectLayoutGeometry(page, positions, challengeOffsetPx) {
+async function expectLayoutGeometry(page, spreadKey, positions, challengeOffsetPx, cardWidthFloor) {
   const table = page.locator('[role="region"][aria-label$="layout"]');
   const tableBox = await table.boundingBox();
   const tableMetrics = await table.evaluate((element) => ({
@@ -114,6 +140,9 @@ async function expectLayoutGeometry(page, positions, challengeOffsetPx) {
     clientHeight: element.clientHeight
   }));
   expect(tableBox).not.toBeNull();
+
+  const cardBoxes = [];
+  const logicalCardWidths = [];
 
   for (let index = 0; index < positions.length; index += 1) {
     const position = positions[index];
@@ -135,6 +164,35 @@ async function expectLayoutGeometry(page, positions, challengeOffsetPx) {
 
     expect(Math.abs(actualX - expectedX), `slot ${index} horizontal centre`).toBeLessThanOrEqual(2);
     expect(Math.abs(actualY - expectedY), `slot ${index} vertical centre`).toBeLessThanOrEqual(2);
+    expect(cardBox.x, `slot ${index} left edge`).toBeGreaterThanOrEqual(tableBox.x - 1);
+    expect(cardBox.y, `slot ${index} top edge`).toBeGreaterThanOrEqual(tableBox.y - 1);
+    expect(cardBox.x + cardBox.width, `slot ${index} right edge`).toBeLessThanOrEqual(tableBox.x + tableBox.width + 1);
+    expect(cardBox.y + cardBox.height, `slot ${index} bottom edge`).toBeLessThanOrEqual(tableBox.y + tableBox.height + 1);
+
+    cardBoxes.push(cardBox);
+    logicalCardWidths.push(await card.evaluate((element) => Number.parseFloat(getComputedStyle(element).width)));
+  }
+
+  for (let leftIndex = 0; leftIndex < cardBoxes.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < cardBoxes.length; rightIndex += 1) {
+      if (spreadKey === 'celtic' && leftIndex === 0 && rightIndex === 1) continue;
+      const left = cardBoxes[leftIndex];
+      const right = cardBoxes[rightIndex];
+      const overlapWidth = Math.min(left.x + left.width, right.x + right.width) - Math.max(left.x, right.x);
+      const overlapHeight = Math.min(left.y + left.height, right.y + right.height) - Math.max(left.y, right.y);
+
+      expect(
+        overlapWidth <= 1 || overlapHeight <= 1,
+        `${spreadKey} slots ${leftIndex}/${rightIndex} overlap by ${overlapWidth.toFixed(2)}x${overlapHeight.toFixed(2)}px`
+      ).toBe(true);
+    }
+  }
+
+  if (cardWidthFloor != null) {
+    expect(
+      Math.min(...logicalCardWidths),
+      `${spreadKey} logical card width floor`
+    ).toBeGreaterThanOrEqual(cardWidthFloor);
   }
 }
 
@@ -144,7 +202,13 @@ for (const viewport of VIEWPORTS) {
     await seedReadingUi(page);
     for (const spread of SPREADS) {
       await openSpread(page, spread.key, spread.positions.length);
-      await expectLayoutGeometry(page, spread.positions, CELTIC_CHALLENGE_OFFSET_BY_VIEWPORT[viewport.width] || 0);
+      await expectLayoutGeometry(
+        page,
+        spread.key,
+        spread.positions,
+        CELTIC_CHALLENGE_OFFSET_BY_VIEWPORT[viewport.width] || 0,
+        CARD_WIDTH_FLOORS[viewport.width][spread.key]
+      );
     }
   });
 }

--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -153,18 +153,19 @@ test('keeps a narrative mention pulse visible beyond the revealed card border', 
   await page.setViewportSize(VIEWPORTS[2]);
   await seedReadingUi(page);
   await openSpread(page, 'single', 1);
-  await page.getByRole('button', { name: /trigger mention pulse/i }).click();
-
-  const ring = page.locator('[data-mention-pulse-ring]');
-  await expect(ring).toBeVisible();
-  const [ringBox, cardBox] = await Promise.all([
-    ring.boundingBox(),
-    page.locator('[data-slot-index="0"] [data-layout-card]').boundingBox()
-  ]);
-  expect(ringBox).not.toBeNull();
+  const cardBox = await page.locator('[data-slot-index="0"] [data-layout-card]').boundingBox();
   expect(cardBox).not.toBeNull();
-  expect(ringBox.x).toBeLessThan(cardBox.x);
-  expect(ringBox.y).toBeLessThan(cardBox.y);
-  expect(ringBox.x + ringBox.width).toBeGreaterThan(cardBox.x + cardBox.width);
-  expect(ringBox.y + ringBox.height).toBeGreaterThan(cardBox.y + cardBox.height);
+  const outsideTopBorder = {
+    x: cardBox.x + 12,
+    y: cardBox.y - (cardBox.height * 0.1) - 4,
+    width: cardBox.width - 24,
+    height: 8
+  };
+  const beforePulse = await page.screenshot({ clip: outsideTopBorder });
+
+  await page.getByRole('button', { name: /trigger mention pulse/i }).click();
+  await expect(page.locator('[data-mention-pulse-ring]')).toBeVisible();
+  const afterPulse = await page.screenshot({ clip: outsideTopBorder });
+
+  expect(afterPulse.equals(beforePulse), 'mention pulse must paint pixels outside the card border').toBe(false);
 });

--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -178,7 +178,12 @@ test('keeps reversed-card labels upright and exposes reversal in every live repr
   const card = page.locator('[data-slot-index="0"] [data-layout-card]');
   await expect(card).toHaveAccessibleName(/the fool, reversed, in theme position\. click to view details\./i);
   await expect(card.getByText('Reversed', { exact: true })).toBeVisible();
-  await expect(card.locator('img[alt="The Fool"]')).toHaveCSS('transform', 'matrix(-1, 0, 0, -1, 0, 0)');
+  const cardImage = card.locator('img[alt="The Fool"]');
+  const face = cardImage.locator('xpath=..');
+  const nameOverlay = face.locator('xpath=./div');
+  await expect(cardImage).toHaveCSS('transform', 'matrix(-1, 0, 0, -1, 0, 0)');
+  await expect(face).toHaveCSS('transform', 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0.1, 1)');
+  await expect(nameOverlay).toHaveCSS('transform', 'none');
 
   await card.hover();
   await expect(page.getByRole('dialog', { name: /the fool, reversed, in theme position card information/i })).toBeVisible();
@@ -191,4 +196,8 @@ test('keeps reversed-card labels upright and exposes reversal in every live repr
   await expect(uprightCard).toHaveAccessibleName(/the fool, in theme position\. click to view details\./i);
   await expect(uprightCard).not.toHaveAccessibleName(/reversed/i);
   await expect(uprightCard.getByLabel('Reversed')).toHaveCount(0);
+
+  await page.goto('/__e2e/spread-layout?spread=single&reversed=1&compact=1', { waitUntil: 'domcontentloaded' });
+  const compactPrimaryCard = page.locator('[data-slot-index="0"] [data-layout-card]');
+  await expect(compactPrimaryCard.getByLabel('Reversed')).toHaveText('⟲');
 });

--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -373,6 +373,141 @@ test('anchors handset Celtic orientation overlays to the compact coordinates', a
   );
 });
 
+// Motion is set per test rather than left to the runner: these cases assert
+// opposite behaviour under each setting.
+async function openStagedCelticReveal(page, reducedMotion) {
+  await page.emulateMedia({ reducedMotion });
+  await page.setViewportSize(VIEWPORTS[2]);
+  await seedReadingUi(page);
+  await page.goto('/__e2e/spread-layout?spread=celtic&staged=1', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('spread-layout-fixture')).toBeVisible();
+  await expect(page.locator('[data-slot-index] [data-layout-card]')).toHaveCount(10, { timeout: 10000 });
+}
+
+// Samples the page for the whole burst window. Started before the click so the
+// first frames of the reveal are covered.
+function sampleRevealWindow(page) {
+  return page.evaluate(async () => {
+    const countCanvases = () => document.querySelectorAll('canvas').length;
+    let peakCanvases = countCanvases();
+    let sawSpark = false;
+    let sawBloom = false;
+    const deadline = performance.now() + 2500;
+
+    while (performance.now() < deadline) {
+      peakCanvases = Math.max(peakCanvases, countCanvases());
+      if (document.querySelector('[data-slot-reveal-spark]')) sawSpark = true;
+      if (document.querySelector('.slot-reveal-bloom')) sawBloom = true;
+      await new Promise((resolve) => { requestAnimationFrame(resolve); });
+    }
+
+    return { peakCanvases, sawSpark, sawBloom };
+  });
+}
+
+test.describe('reveal burst under normal motion', () => {
+  test('reveals a full Celtic spread without adding a canvas per slot', async ({ page }) => {
+    await openStagedCelticReveal(page, 'no-preference');
+    const baselineCanvases = await page.locator('canvas').count();
+
+    const sampled = sampleRevealWindow(page);
+    await page.getByRole('button', { name: 'Reveal all' }).click();
+    const { peakCanvases, sawSpark, sawBloom } = await sampled;
+
+    expect(peakCanvases, 'reveal-all must not add a canvas per slot').toBe(baselineCanvases);
+    expect(sawSpark, 'the reveal must render burst sparks').toBe(true);
+    expect(sawBloom, 'the slot reveal bloom must still run').toBe(true);
+  });
+
+  test('throws burst sparks radially outward from the slot', async ({ page }) => {
+    await openStagedCelticReveal(page, 'no-preference');
+
+    const measured = page.evaluate(async () => {
+      const deadline = performance.now() + 3000;
+      while (performance.now() < deadline) {
+        const burst = document.querySelector('[data-slot-reveal-burst]');
+        if (burst) {
+          const sparks = [...burst.querySelectorAll('[data-slot-reveal-spark]')];
+          const readTranslation = (spark, progress) => {
+            const animation = spark.getAnimations()[0];
+            if (!animation) return null;
+            animation.pause();
+            animation.currentTime = animation.effect.getComputedTiming().activeDuration * progress;
+            const matrix = new DOMMatrixReadOnly(getComputedStyle(spark).transform);
+            return { x: matrix.m41, y: matrix.m42 };
+          };
+
+          return sparks.map((spark) => {
+            const start = readTranslation(spark, 0);
+            const end = readTranslation(spark, 0.9);
+            if (!start || !end) return null;
+            return {
+              startReach: Math.hypot(start.x, start.y),
+              endReach: Math.hypot(end.x, end.y),
+              endDirection: (((Math.atan2(end.y, end.x) * 180) / Math.PI) + 360) % 360
+            };
+          });
+        }
+        await new Promise((resolve) => { requestAnimationFrame(resolve); });
+      }
+      return null;
+    });
+
+    await page.getByRole('button', { name: 'Reveal all' }).click();
+    const sparks = await measured;
+
+    expect(sparks, 'a burst must render sparks with animations').not.toBeNull();
+    expect(sparks.length).toBeGreaterThanOrEqual(6);
+
+    sparks.forEach((spark, index) => {
+      expect(spark, `spark ${index} must be animated`).not.toBeNull();
+      expect(spark.startReach, `spark ${index} must start at the slot centre`).toBeLessThanOrEqual(1);
+      expect(spark.endReach, `spark ${index} must travel outward`).toBeGreaterThanOrEqual(20);
+    });
+
+    const step = 360 / sparks.length;
+    sparks.forEach((spark, index) => {
+      const expectedDirection = (index * step) % 360;
+      expect(
+        Math.abs(spark.endDirection - expectedDirection),
+        `spark ${index} must fan to ${expectedDirection} degrees`
+      ).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+test('disables the reveal burst under reduced motion', async ({ page }) => {
+  await openStagedCelticReveal(page, 'reduce');
+
+  const observed = page.evaluate(async () => {
+    const deadline = performance.now() + 3000;
+    while (performance.now() < deadline) {
+      const spark = document.querySelector('[data-slot-reveal-spark]');
+      if (spark) {
+        const style = getComputedStyle(spark);
+        const raw = style.animationDuration;
+        // Normalise the unit: the stylesheet declares seconds, the global
+        // reduced-motion override declares milliseconds.
+        const durationMs = raw.endsWith('ms')
+          ? Number.parseFloat(raw)
+          : Number.parseFloat(raw) * 1000;
+        return { durationMs, raw, opacity: Number.parseFloat(style.opacity) };
+      }
+      await new Promise((resolve) => { requestAnimationFrame(resolve); });
+    }
+    return null;
+  });
+
+  await page.getByRole('button', { name: 'Reveal all' }).click();
+  const spark = await observed;
+
+  expect(spark, 'the burst markup must still render under reduced motion').not.toBeNull();
+  expect(
+    spark.durationMs,
+    'the global reduced-motion block must collapse the burst animation'
+  ).toBeLessThanOrEqual(1);
+});
+
 test('keeps a narrative mention pulse visible beyond the revealed card border', async ({ page }) => {
   await page.setViewportSize(VIEWPORTS[2]);
   await seedReadingUi(page);

--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -169,3 +169,26 @@ test('keeps a narrative mention pulse visible beyond the revealed card border', 
 
   expect(afterPulse.equals(beforePulse), 'mention pulse must paint pixels outside the card border').toBe(false);
 });
+
+test('keeps reversed-card labels upright and exposes reversal in every live representation', async ({ page }) => {
+  await page.setViewportSize(VIEWPORTS[2]);
+  await seedReadingUi(page);
+  await page.goto('/__e2e/spread-layout?spread=single&reversed=1', { waitUntil: 'domcontentloaded' });
+
+  const card = page.locator('[data-slot-index="0"] [data-layout-card]');
+  await expect(card).toHaveAccessibleName(/the fool, reversed, in theme position\. click to view details\./i);
+  await expect(card.getByText('Reversed', { exact: true })).toBeVisible();
+  await expect(card.locator('img[alt="The Fool"]')).toHaveCSS('transform', 'matrix(-1, 0, 0, -1, 0, 0)');
+
+  await card.hover();
+  await expect(page.getByRole('dialog', { name: /the fool, reversed, in theme position card information/i })).toBeVisible();
+
+  const compactCard = page.getByRole('group', { name: /theme: the fool, reversed/i });
+  await expect(compactCard).toContainText('⟲');
+
+  await page.goto('/__e2e/spread-layout?spread=single', { waitUntil: 'domcontentloaded' });
+  const uprightCard = page.locator('[data-slot-index="0"] [data-layout-card]');
+  await expect(uprightCard).toHaveAccessibleName(/the fool, in theme position\. click to view details\./i);
+  await expect(uprightCard).not.toHaveAccessibleName(/reversed/i);
+  await expect(uprightCard.getByLabel('Reversed')).toHaveCount(0);
+});

--- a/e2e/spread-layout.spec.js
+++ b/e2e/spread-layout.spec.js
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test';
+
+const VIEWPORTS = [
+  { width: 390, height: 844 },
+  { width: 768, height: 1024 },
+  { width: 1280, height: 900 }
+];
+
+const CELTIC_CHALLENGE_OFFSET_BY_VIEWPORT = {
+  390: 18,
+  768: 32.725,
+  1280: 43.990625
+};
+
+const SPREADS = [
+  {
+    key: 'single',
+    name: 'One-Card',
+    positions: [{ x: 50, y: 50 }]
+  },
+  {
+    key: 'threeCard',
+    name: 'Three-Card',
+    positions: [
+      { x: 20, y: 50 },
+      { x: 50, y: 50 },
+      { x: 80, y: 50 }
+    ]
+  },
+  {
+    key: 'fiveCard',
+    name: 'Five-Card',
+    positions: [
+      { x: 50, y: 20 },
+      { x: 20, y: 50 },
+      { x: 50, y: 50 },
+      { x: 80, y: 50 },
+      { x: 50, y: 80 }
+    ]
+  },
+  {
+    key: 'decision',
+    name: 'Decision',
+    positions: [
+      { x: 50, y: 20 },
+      { x: 25, y: 50 },
+      { x: 75, y: 50 },
+      { x: 50, y: 70 },
+      { x: 50, y: 80 }
+    ]
+  },
+  {
+    key: 'relationship',
+    name: 'Relationship',
+    positions: [
+      { x: 30, y: 50 },
+      { x: 70, y: 50 },
+      { x: 50, y: 75 },
+      { x: 25, y: 22 },
+      { x: 75, y: 22 }
+    ]
+  },
+  {
+    key: 'celtic',
+    name: 'Celtic',
+    positions: [
+      { x: 35, y: 50 },
+      { x: 35, y: 50, challengeOffset: true },
+      { x: 15, y: 50 },
+      { x: 55, y: 50 },
+      { x: 35, y: 20 },
+      { x: 35, y: 80 },
+      { x: 80, y: 80 },
+      { x: 80, y: 60 },
+      { x: 80, y: 40 },
+      { x: 80, y: 20 }
+    ]
+  }
+];
+
+function seedReadingUi(page) {
+  return page.addInitScript(() => {
+    localStorage.setItem('tarot-onboarding-complete', 'true');
+    localStorage.setItem('tarot-nudge-state', JSON.stringify({
+      readingCount: 1,
+      hasSeenRitualNudge: true,
+      hasSeenGestureCoach: true,
+      hasSeenJournalNudge: true,
+      journalSaveCount: 0,
+      hasDismissedAccountNudge: false
+    }));
+    sessionStorage.setItem('tarot-prepare-sections', JSON.stringify({
+      intention: false,
+      experience: false,
+      ritual: true,
+      audio: false
+    }));
+  });
+}
+
+async function openSpread(page, spreadKey, expectedCardCount) {
+  await page.goto(`/__e2e/spread-layout?spread=${spreadKey}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('spread-layout-fixture')).toBeVisible();
+  await expect(page.locator('[data-slot-index] [data-layout-card]')).toHaveCount(expectedCardCount, { timeout: 10000 });
+}
+
+async function expectLayoutGeometry(page, positions, challengeOffsetPx) {
+  const table = page.locator('[role="region"][aria-label$="layout"]');
+  const tableBox = await table.boundingBox();
+  const tableMetrics = await table.evaluate((element) => ({
+    clientLeft: element.clientLeft,
+    clientTop: element.clientTop,
+    clientWidth: element.clientWidth,
+    clientHeight: element.clientHeight
+  }));
+  expect(tableBox).not.toBeNull();
+
+  for (let index = 0; index < positions.length; index += 1) {
+    const position = positions[index];
+    const slot = page.locator(`[data-slot-index="${index}"]`);
+    const card = slot.locator('[data-layout-card]');
+    const cardBox = await card.boundingBox();
+    const badgeBox = await slot.locator('[data-layout-card] > div[aria-hidden="true"]').first().boundingBox();
+
+    expect(cardBox).not.toBeNull();
+    expect(badgeBox).not.toBeNull();
+    expect(badgeBox.width).toBeGreaterThan(0);
+    expect(badgeBox.height).toBeGreaterThan(0);
+
+    const offsetPx = position.challengeOffset ? challengeOffsetPx : (position.offsetPx || 0);
+    const expectedX = tableBox.x + tableMetrics.clientLeft + (tableMetrics.clientWidth * (position.x / 100)) + offsetPx;
+    const expectedY = tableBox.y + tableMetrics.clientTop + (tableMetrics.clientHeight * (position.y / 100));
+    const actualX = cardBox.x + (cardBox.width / 2);
+    const actualY = cardBox.y + (cardBox.height / 2);
+
+    expect(Math.abs(actualX - expectedX), `slot ${index} horizontal centre`).toBeLessThanOrEqual(2);
+    expect(Math.abs(actualY - expectedY), `slot ${index} vertical centre`).toBeLessThanOrEqual(2);
+  }
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`keeps revealed spread cards centred and unclipped at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await seedReadingUi(page);
+    for (const spread of SPREADS) {
+      await openSpread(page, spread.key, spread.positions.length);
+      await expectLayoutGeometry(page, spread.positions, CELTIC_CHALLENGE_OFFSET_BY_VIEWPORT[viewport.width] || 0);
+    }
+  });
+}
+
+test('keeps a narrative mention pulse visible beyond the revealed card border', async ({ page }) => {
+  await page.setViewportSize(VIEWPORTS[2]);
+  await seedReadingUi(page);
+  await openSpread(page, 'single', 1);
+  await page.getByRole('button', { name: /trigger mention pulse/i }).click();
+
+  const ring = page.locator('[data-mention-pulse-ring]');
+  await expect(ring).toBeVisible();
+  const [ringBox, cardBox] = await Promise.all([
+    ring.boundingBox(),
+    page.locator('[data-slot-index="0"] [data-layout-card]').boundingBox()
+  ]);
+  expect(ringBox).not.toBeNull();
+  expect(cardBox).not.toBeNull();
+  expect(ringBox.x).toBeLessThan(cardBox.x);
+  expect(ringBox.y).toBeLessThan(cardBox.y);
+  expect(ringBox.x + ringBox.width).toBeGreaterThan(cardBox.x + cardBox.width);
+  expect(ringBox.y + ringBox.height).toBeGreaterThan(cardBox.y + cardBox.height);
+});

--- a/src/components/AnimatedRoutes.jsx
+++ b/src/components/AnimatedRoutes.jsx
@@ -17,6 +17,9 @@ const GovernanceCritiquePage = lazy(() => import('../pages/GovernanceCritiquePag
 const ResetPasswordPage = lazy(() => import('../pages/ResetPasswordPage.jsx'));
 const VerifyEmailPage = lazy(() => import('../pages/VerifyEmailPage.jsx'));
 const OAuthCallbackPage = lazy(() => import('../pages/OAuthCallbackPage.jsx'));
+const SpreadLayoutFixture = import.meta.env.DEV
+  ? lazy(() => import('./SpreadLayoutFixture.jsx'))
+  : null;
 
 // Minimal loading fallback for route transitions
 function RouteLoader() {
@@ -207,6 +210,9 @@ export function AnimatedRoutes() {
           <Route path="/reset-password" element={<PageTransition><ResetPasswordPage /></PageTransition>} />
           <Route path="/verify-email" element={<PageTransition><VerifyEmailPage /></PageTransition>} />
           <Route path="/auth/callback" element={<PageTransition><OAuthCallbackPage /></PageTransition>} />
+          {SpreadLayoutFixture && (
+            <Route path="/__e2e/spread-layout" element={<SpreadLayoutFixture />} />
+          )}
           <Route path="*" element={<PageTransition><TarotReading /></PageTransition>} />
         </Routes>
       </Suspense>

--- a/src/components/CardInfoPopover.jsx
+++ b/src/components/CardInfoPopover.jsx
@@ -105,7 +105,7 @@ export function CardInfoPopover({
           transform: popoverPos.transform
         }}
         role="dialog"
-        aria-label={`${card.name} card information`}
+        aria-label={`${card.name}${card.isReversed ? ', reversed' : ', upright'}${positionLabel ? `, in ${positionLabel} position` : ''} card information`}
         onMouseLeave={() => onClose?.()}
       >
         <div className="flex items-start justify-between gap-3">
@@ -156,7 +156,7 @@ export function CardInfoPopover({
           <span
             className={`inline-flex items-center rounded-full px-2.5 py-1 text-2xs border ${
               card?.isReversed
-                ? 'bg-accent/20 border-accent/40 text-accent'
+                ? 'bg-surface-muted/90 text-accent border-accent/50'
                 : 'bg-secondary/20 border-secondary/40 text-secondary'
             }`}
           >

--- a/src/components/ParticleLayer.jsx
+++ b/src/components/ParticleLayer.jsx
@@ -23,7 +23,6 @@ const PRESET_COUNTS = {
   idle: 24,
   shuffle: 46,
   'deal-trail': 52,
-  'reveal-burst': 70,
   'element-ambient': 30,
   'narrative-glow': 28
 };
@@ -91,13 +90,6 @@ function getPresetConfig({ preset, color, reducedMotion, intensity = 1 }) {
     shared.particles.shape.type = ['circle', 'star'];
     shared.particles.size.value = { min: 1, max: 2.5 };
     shared.particles.opacity.value = { min: 0.14, max: 0.65 };
-  }
-
-  if (preset === 'reveal-burst') {
-    shared.particles.move.speed = reducedMotion ? 0.7 : 2.4;
-    shared.particles.shape.type = ['circle', 'triangle', 'star'];
-    shared.particles.size.value = { min: 1, max: 4.2 };
-    shared.particles.opacity.value = { min: 0.22, max: 0.85 };
   }
 
   if (preset === 'element-ambient') {

--- a/src/components/ReadingBoard.jsx
+++ b/src/components/ReadingBoard.jsx
@@ -5,7 +5,7 @@ import { getCardImage, getOrientationMeaning } from '../lib/cardLookup';
 import { getDrawerGradient } from '../lib/suitColors';
 import { useModalA11y } from '../hooks/useModalA11y';
 import { useReducedMotion } from '../hooks/useReducedMotion';
-import { SPREAD_LAYOUTS } from '../lib/spreadLayouts';
+import { getSpreadLayout } from '../lib/spreadLayouts';
 import { SpreadTable } from './SpreadTable';
 import { getNextUnrevealedIndex, getPositionLabel } from './readingBoardUtils';
 
@@ -23,12 +23,14 @@ const CELTIC_POSITION_LABELS = [
   'Outcome'
 ];
 
-// Derive the responsive position map from the live Celtic layout.
-const CELTIC_MAP_POSITIONS = SPREAD_LAYOUTS.celtic.positions.map((position) => ({
-  x: position.x,
-  y: position.y,
-  rotated: Math.abs(position.rotate || 0) % 180 === 90
-}));
+// Derive the responsive position map from whichever Celtic layout is on screen.
+const toCelticMapPositions = (isHandset) => (
+  getSpreadLayout('celtic', { isHandset }).positions.map((position) => ({
+    x: position.x,
+    y: position.y,
+    rotated: Math.abs(position.rotate || 0) % 180 === 90
+  }))
+);
 
 function CardDetailContent({
   focusedCardData,
@@ -355,7 +357,7 @@ function CardFocusOverlay({
  * Celtic Cross map overlay - shows numbered position layout
  * Helps users understand the complex Celtic Cross layout on mobile
  */
-function CelticCrossMapOverlay({ onClose }) {
+function CelticCrossMapOverlay({ onClose, positions }) {
   return (
     <div
       className="absolute inset-0 z-20 rounded-2xl sm:rounded-3xl overflow-hidden"
@@ -369,7 +371,7 @@ function CelticCrossMapOverlay({ onClose }) {
 
       {/* Position markers */}
       <div className="relative w-full h-full">
-        {CELTIC_MAP_POSITIONS.map((pos, i) => (
+        {positions.map((pos, i) => (
           <div
             key={`map-pos-${i}`}
             className="absolute transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-0.5"
@@ -441,6 +443,7 @@ export function ReadingBoard({
   const [showCelticMap, setShowCelticMap] = useState(false);
   const isCelticCross = spreadKey === 'celtic';
   const showMapToggle = isCelticCross && isHandset;
+  const celticMapPositions = useMemo(() => toCelticMapPositions(isHandset), [isHandset]);
   const revealStatusText = allowBoardReveal
     ? `Tap positions to reveal. ${nextLabel ? `Next: ${nextLabel}.` : 'All cards revealed.'}`
     : `Draw from the deck to place your first card.${nextLabel ? ` Next: ${nextLabel}.` : ''}`;
@@ -480,7 +483,9 @@ export function ReadingBoard({
   if (!reading) return null;
 
   return (
-    <div className="space-y-3">
+    // Handset: reserve a band under the board for the relocated Tactile Lens
+    // button, and as defence in depth against cards reaching the Reset control.
+    <div className={`space-y-3 ${isHandset ? 'pb-16' : ''}`}>
       <p className="sr-only" aria-live="polite">{revealStatusTextWithFocusHint}</p>
       {!cardsOnly && (
         <div className="px-4 flex items-center justify-center gap-3">
@@ -528,10 +533,14 @@ export function ReadingBoard({
           flashNextSlot={flashNextSlot}
           mentionPulse={narrativeMentionPulse}
           cardsOnly={cardsOnly}
+          isHandset={isHandset}
         />
         {/* Celtic Cross map overlay */}
         {showCelticMap && isCelticCross && (
-          <CelticCrossMapOverlay onClose={() => setShowCelticMap(false)} />
+          <CelticCrossMapOverlay
+            onClose={() => setShowCelticMap(false)}
+            positions={celticMapPositions}
+          />
         )}
       </div>
       {!isHandset && (

--- a/src/components/ReadingBoard.jsx
+++ b/src/components/ReadingBoard.jsx
@@ -5,6 +5,7 @@ import { getCardImage, getOrientationMeaning } from '../lib/cardLookup';
 import { getDrawerGradient } from '../lib/suitColors';
 import { useModalA11y } from '../hooks/useModalA11y';
 import { useReducedMotion } from '../hooks/useReducedMotion';
+import { SPREAD_LAYOUTS } from '../lib/spreadLayouts';
 import { SpreadTable } from './SpreadTable';
 import { getNextUnrevealedIndex, getPositionLabel } from './readingBoardUtils';
 
@@ -22,19 +23,12 @@ const CELTIC_POSITION_LABELS = [
   'Outcome'
 ];
 
-// Celtic Cross map overlay positions (percentage-based for responsive layout)
-const CELTIC_MAP_POSITIONS = [
-  { x: 35, y: 50 },        // 1: Present (center)
-  { x: 35, y: 50, rotated: true }, // 2: Challenge (crossing)
-  { x: 15, y: 50 },        // 3: Past
-  { x: 55, y: 50 },        // 4: Future
-  { x: 35, y: 20 },        // 5: Conscious
-  { x: 35, y: 80 },        // 6: Subconscious
-  { x: 80, y: 80 },        // 7: Advice
-  { x: 80, y: 60 },        // 8: External
-  { x: 80, y: 40 },        // 9: Hopes/Fears
-  { x: 80, y: 20 }         // 10: Outcome
-];
+// Derive the responsive position map from the live Celtic layout.
+const CELTIC_MAP_POSITIONS = SPREAD_LAYOUTS.celtic.positions.map((position) => ({
+  x: position.x,
+  y: position.y,
+  rotated: Math.abs(position.rotate || 0) % 180 === 90
+}));
 
 function CardDetailContent({
   focusedCardData,

--- a/src/components/SpreadLayoutFixture.jsx
+++ b/src/components/SpreadLayoutFixture.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { MAJOR_ARCANA } from '../data/majorArcana';
 import { ReadingBoard } from './ReadingBoard';
-import { SpreadTableCompact } from './SpreadTable';
+import { SpreadTable, SpreadTableCompact } from './SpreadTable';
 
 const SUPPORTED_SPREADS = new Set(['single', 'threeCard', 'fiveCard', 'decision', 'relationship', 'celtic']);
 
@@ -10,6 +10,7 @@ export function SpreadLayoutFixture() {
   const [reflections, setReflections] = useState({});
   const spreadKey = new URLSearchParams(window.location.search).get('spread');
   const showReversedCard = new URLSearchParams(window.location.search).get('reversed') === '1';
+  const showPrimaryCompact = new URLSearchParams(window.location.search).get('compact') === '1';
   const safeSpreadKey = SUPPORTED_SPREADS.has(spreadKey) ? spreadKey : 'single';
   const cardCount = safeSpreadKey === 'single' ? 1 : safeSpreadKey === 'celtic' ? 10 : 5;
   const reading = useMemo(() => (
@@ -30,26 +31,38 @@ export function SpreadLayoutFixture() {
       >
         Trigger mention pulse
       </button>
-      <ReadingBoard
-        spreadKey={safeSpreadKey}
-        reading={reading}
-        revealedCards={revealedCards}
-        revealCard={() => {}}
-        onCardClick={() => {}}
-        focusedCardData={null}
-        onCloseDetail={() => {}}
-        reflections={reflections}
-        setReflections={setReflections}
-        onOpenModal={() => {}}
-        onNavigateCard={() => {}}
-        canNavigatePrev={false}
-        canNavigateNext={false}
-        navigationLabel=""
-        revealStage="action"
-        narrativeMentionPulse={mentionPulse}
-        isHandset={isHandset}
-        cardsOnly
-      />
+      {showPrimaryCompact ? (
+        <SpreadTable
+          spreadKey={safeSpreadKey}
+          cards={reading}
+          revealedIndices={revealedCards}
+          onCardClick={() => {}}
+          onCardReveal={() => {}}
+          compact
+          cardsOnly
+        />
+      ) : (
+        <ReadingBoard
+          spreadKey={safeSpreadKey}
+          reading={reading}
+          revealedCards={revealedCards}
+          revealCard={() => {}}
+          onCardClick={() => {}}
+          focusedCardData={null}
+          onCloseDetail={() => {}}
+          reflections={reflections}
+          setReflections={setReflections}
+          onOpenModal={() => {}}
+          onNavigateCard={() => {}}
+          canNavigatePrev={false}
+          canNavigateNext={false}
+          navigationLabel=""
+          revealStage="action"
+          narrativeMentionPulse={mentionPulse}
+          isHandset={isHandset}
+          cardsOnly
+        />
+      )}
       <SpreadTableCompact
         spreadKey={safeSpreadKey}
         cards={reading}

--- a/src/components/SpreadLayoutFixture.jsx
+++ b/src/components/SpreadLayoutFixture.jsx
@@ -19,7 +19,10 @@ export function SpreadLayoutFixture() {
       isReversed: showReversedCard && index === 0
     }))
   ), [cardCount, showReversedCard]);
-  const revealedCards = useMemo(() => new Set(reading.map((_, index) => index)), [reading]);
+  const stageReveal = new URLSearchParams(window.location.search).get('staged') === '1';
+  const allRevealed = useMemo(() => new Set(reading.map((_, index) => index)), [reading]);
+  const [stagedRevealed, setStagedRevealed] = useState(() => new Set());
+  const revealedCards = stageReveal ? stagedRevealed : allRevealed;
   const isHandset = window.innerWidth < 640;
 
   return (
@@ -31,6 +34,15 @@ export function SpreadLayoutFixture() {
       >
         Trigger mention pulse
       </button>
+      {stageReveal && (
+        <button
+          type="button"
+          onClick={() => setStagedRevealed(allRevealed)}
+          className="mb-3 ml-2 rounded-full border border-secondary/40 px-3 py-2 text-sm text-muted"
+        >
+          Reveal all
+        </button>
+      )}
       {showPrimaryCompact ? (
         <SpreadTable
           spreadKey={safeSpreadKey}

--- a/src/components/SpreadLayoutFixture.jsx
+++ b/src/components/SpreadLayoutFixture.jsx
@@ -63,6 +63,16 @@ export function SpreadLayoutFixture() {
           cardsOnly
         />
       )}
+      {/* Mirrors the reveal scene's Reset control so layout regressions that
+          spill cards onto it are caught here. */}
+      <div className="text-center mt-3 sm:mt-4">
+        <button
+          type="button"
+          className="inline-flex items-center justify-center min-h-touch px-4 py-2 rounded-full border border-accent/50 text-muted text-xs sm:text-sm"
+        >
+          Reset reveals
+        </button>
+      </div>
       <SpreadTableCompact
         spreadKey={safeSpreadKey}
         cards={reading}

--- a/src/components/SpreadLayoutFixture.jsx
+++ b/src/components/SpreadLayoutFixture.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { MAJOR_ARCANA } from '../data/majorArcana';
 import { ReadingBoard } from './ReadingBoard';
+import { SpreadTableCompact } from './SpreadTable';
 
 const SUPPORTED_SPREADS = new Set(['single', 'threeCard', 'fiveCard', 'decision', 'relationship', 'celtic']);
 
@@ -8,11 +9,15 @@ export function SpreadLayoutFixture() {
   const [mentionPulse, setMentionPulse] = useState(null);
   const [reflections, setReflections] = useState({});
   const spreadKey = new URLSearchParams(window.location.search).get('spread');
+  const showReversedCard = new URLSearchParams(window.location.search).get('reversed') === '1';
   const safeSpreadKey = SUPPORTED_SPREADS.has(spreadKey) ? spreadKey : 'single';
   const cardCount = safeSpreadKey === 'single' ? 1 : safeSpreadKey === 'celtic' ? 10 : 5;
   const reading = useMemo(() => (
-    MAJOR_ARCANA.slice(0, cardCount).map((card) => ({ ...card, isReversed: false }))
-  ), [cardCount]);
+    MAJOR_ARCANA.slice(0, cardCount).map((card, index) => ({
+      ...card,
+      isReversed: showReversedCard && index === 0
+    }))
+  ), [cardCount, showReversedCard]);
   const revealedCards = useMemo(() => new Set(reading.map((_, index) => index)), [reading]);
   const isHandset = window.innerWidth < 640;
 
@@ -44,6 +49,11 @@ export function SpreadLayoutFixture() {
         narrativeMentionPulse={mentionPulse}
         isHandset={isHandset}
         cardsOnly
+      />
+      <SpreadTableCompact
+        spreadKey={safeSpreadKey}
+        cards={reading}
+        revealedIndices={revealedCards}
       />
     </main>
   );

--- a/src/components/SpreadLayoutFixture.jsx
+++ b/src/components/SpreadLayoutFixture.jsx
@@ -1,0 +1,52 @@
+import { useMemo, useState } from 'react';
+import { MAJOR_ARCANA } from '../data/majorArcana';
+import { ReadingBoard } from './ReadingBoard';
+
+const SUPPORTED_SPREADS = new Set(['single', 'threeCard', 'fiveCard', 'decision', 'relationship', 'celtic']);
+
+export function SpreadLayoutFixture() {
+  const [mentionPulse, setMentionPulse] = useState(null);
+  const [reflections, setReflections] = useState({});
+  const spreadKey = new URLSearchParams(window.location.search).get('spread');
+  const safeSpreadKey = SUPPORTED_SPREADS.has(spreadKey) ? spreadKey : 'single';
+  const cardCount = safeSpreadKey === 'single' ? 1 : safeSpreadKey === 'celtic' ? 10 : 5;
+  const reading = useMemo(() => (
+    MAJOR_ARCANA.slice(0, cardCount).map((card) => ({ ...card, isReversed: false }))
+  ), [cardCount]);
+  const revealedCards = useMemo(() => new Set(reading.map((_, index) => index)), [reading]);
+  const isHandset = window.innerWidth < 640;
+
+  return (
+    <main data-testid="spread-layout-fixture" className="min-h-screen px-3 py-4">
+      <button
+        type="button"
+        onClick={() => setMentionPulse({ id: Date.now(), index: 0 })}
+        className="mb-3 rounded-full border border-secondary/40 px-3 py-2 text-sm text-muted"
+      >
+        Trigger mention pulse
+      </button>
+      <ReadingBoard
+        spreadKey={safeSpreadKey}
+        reading={reading}
+        revealedCards={revealedCards}
+        revealCard={() => {}}
+        onCardClick={() => {}}
+        focusedCardData={null}
+        onCloseDetail={() => {}}
+        reflections={reflections}
+        setReflections={setReflections}
+        onOpenModal={() => {}}
+        onNavigateCard={() => {}}
+        canNavigatePrev={false}
+        canNavigateNext={false}
+        navigationLabel=""
+        revealStage="action"
+        narrativeMentionPulse={mentionPulse}
+        isHandset={isHandset}
+        cardsOnly
+      />
+    </main>
+  );
+}
+
+export default SpreadLayoutFixture;

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -1075,7 +1075,7 @@ export function SpreadTable({
               ariaDisabled={isRevealDisabled}
               ariaLabel={card
                 ? isRevealed
-                  ? `${card.name} in ${positionLabel} position. Click to view details.`
+                  ? `${card.name}${card.isReversed ? ', reversed' : ''}, in ${positionLabel} position. Click to view details.`
                   : disableReveal
                     ? `${positionLabel} position. Draw from the deck to reveal.`
                     : `Card in ${positionLabel} position. Click to reveal.`
@@ -1109,15 +1109,16 @@ export function SpreadTable({
                         style={{
                           backfaceVisibility: 'hidden',
                           WebkitBackfaceVisibility: 'hidden',
-                          transform: displayCard.isReversed
-                            ? 'rotateZ(180deg) translateZ(0.1px)'
-                            : 'translateZ(0.1px)'
+                          transform: 'translateZ(0.1px)'
                         }}
                       >
                         <img
                           src={displayImage}
                           alt={displayCard.name}
                           className="w-full h-full object-cover"
+                          style={{
+                            transform: displayCard.isReversed ? 'rotateZ(180deg)' : undefined
+                          }}
                           loading={isNext || isRevealed ? 'eager' : 'lazy'}
                           decoding="async"
                           onError={(e) => {
@@ -1125,10 +1126,18 @@ export function SpreadTable({
                             e.target.src = FALLBACK_IMAGE;
                           }}
                         />
-                        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-main/80 to-transparent p-0.5 xs:p-1 sm:p-1">
-                          <span className={`${compact ? 'text-2xs xs:text-2xs' : 'text-2xs xs:text-2xs sm:text-2xs'} text-main font-semibold leading-tight block truncate`}>
+                        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-main/80 to-transparent p-0.5 xs:p-1 sm:p-1 flex items-center gap-1">
+                          <span className={`${compact ? 'text-2xs xs:text-2xs' : 'text-2xs xs:text-2xs sm:text-2xs'} text-main font-semibold leading-tight min-w-0 truncate`}>
                             {displayCard.name.replace(/^The /, '')}
                           </span>
+                          {displayCard.isReversed ? (
+                            <span
+                              className="inline-flex shrink-0 items-center rounded-full border bg-surface-muted/90 text-accent border-accent/50 px-1.5 py-0.5 text-2xs font-semibold leading-none"
+                              aria-label="Reversed"
+                            >
+                              {compact ? '⟲' : 'Reversed'}
+                            </span>
+                          ) : null}
                         </div>
                       </div>
                       <div
@@ -1310,6 +1319,7 @@ export function SpreadTableCompact({
         const card = cards?.[i];
         const isRevealed = revealedIndices?.has?.(i) || false;
         const isActive = activeSlot === i;
+        const positionLabel = getPositionLabel(spreadInfo, i, pos);
 
         const slotClasses = `
           w-7 h-10 xs:w-8 xs:h-11 rounded border
@@ -1326,11 +1336,13 @@ export function SpreadTableCompact({
           ${isInteractive ? 'cursor-pointer hover:border-primary/60 touch-manipulation focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary' : ''}
         `;
 
+        const accessibleLabel = `${positionLabel}${card ? `: ${card.name}${card.isReversed ? ', reversed' : ''}` : ''}`;
         const content = (
           <>
             {card && isRevealed ? (
-              <span className="text-2xs xs:text-2xs text-secondary font-bold">
-                {card.name.charAt(0)}
+              <span className="inline-flex items-center gap-0.5 text-2xs xs:text-2xs text-secondary font-bold">
+                <span aria-hidden="true">{card.name.charAt(0)}</span>
+                {card.isReversed ? <span aria-label="Reversed">⟲</span> : null}
               </span>
             ) : card ? (
               <span className="text-2xs xs:text-2xs text-primary">?</span>
@@ -1346,7 +1358,7 @@ export function SpreadTableCompact({
               onClick={() => onSlotClick(i)}
               role="option"
               aria-selected={isActive}
-              aria-label={`${pos.label || `Position ${i + 1}`}${card ? `: ${card.name}` : ''}`}
+              aria-label={accessibleLabel}
               className={slotClasses}
             >
               {content}
@@ -1358,7 +1370,9 @@ export function SpreadTableCompact({
           <div
             key={i}
             className={slotClasses}
-            title={pos.label || `Position ${i + 1}`}
+            role="group"
+            aria-label={accessibleLabel}
+            title={positionLabel}
           >
             {content}
           </div>

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -501,7 +501,7 @@ function AnimatedCardButton({
       style={{
         ...style,
         display: isHidden ? 'none' : undefined,
-        scale: positionScale || 1,
+        '--layout-card-scale': positionScale || 1,
         rotate: positionRotate ? `${positionRotate}deg` : undefined
       }}
     >
@@ -932,22 +932,26 @@ export function SpreadTable({
         );
 
         return (
-          <SlotPulseWrapper
+          <div
             key={i}
-            // Keep pulse for empty placeholders, but avoid scaling a populated
-            // hidden card slot (it can desync deck-to-slot landing alignment).
-            active={isNext && !card}
-            prefersReducedMotion={prefersReducedMotion}
-            className="absolute transform -translate-x-1/2 -translate-y-1/2"
+            className="absolute"
             style={{
               left: `${pos.x}%`,
               top: `${pos.y}%`,
+              translate: '-50% -50%',
               zIndex: isRevealed ? 10 : card ? 5 : 1,
               marginLeft: pos.offsetX ? `${pos.offsetX}%` : 0
             }}
             data-slot-index={i}
             id={`spread-slot-${i}`}
           >
+            <SlotPulseWrapper
+              // Keep pulse for empty placeholders, but avoid scaling a populated
+              // hidden card slot (it can desync deck-to-slot landing alignment).
+              active={isNext && !card}
+              prefersReducedMotion={prefersReducedMotion}
+              className="relative flex"
+            >
             {!card && (
               // Empty placeholder - dual-trigger: tappable to deal card here
               <button
@@ -1005,15 +1009,15 @@ export function SpreadTable({
               positionRotate={pos.rotate}
               className={`
                 ${sizeClass}
-                relative rounded-lg border-2 cursor-pointer overflow-hidden
+                relative rounded-lg border-2 cursor-pointer overflow-visible
                 transition-all touch-manipulation
                 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2 focus-visible:ring-offset-main
                 disabled:opacity-60 disabled:cursor-not-allowed
                 ${isRevealed
                   ? 'shadow-lg'
                   : showRevealPill
-                    ? 'border-primary/70 ring-2 ring-primary/30 shadow-md shadow-primary/20 hover:border-primary/80 active:scale-95'
-                    : 'border-primary/35 shadow-[0_0_16px_var(--primary-20)] hover:border-primary/50 active:scale-95'
+                    ? 'border-primary/70 ring-2 ring-primary/30 shadow-md shadow-primary/20 hover:border-primary/80'
+                    : 'border-primary/35 shadow-[0_0_16px_var(--primary-20)] hover:border-primary/50'
                 }
               `}
               style={{
@@ -1101,7 +1105,7 @@ export function SpreadTable({
                       }}
                     >
                       <div
-                        className="absolute inset-0 bg-surface flex items-center justify-center"
+                        className="absolute inset-0 rounded-[inherit] overflow-hidden bg-surface flex items-center justify-center"
                         style={{
                           backfaceVisibility: 'hidden',
                           WebkitBackfaceVisibility: 'hidden',
@@ -1137,6 +1141,7 @@ export function SpreadTable({
                         />
                         <OneShotRing
                           key={`mention-${mentionPulseId}-${i}`}
+                          data-mention-pulse-ring
                           active={shouldMentionPulse}
                           prefersReducedMotion={prefersReducedMotion}
                           className="absolute inset-[-10%] rounded-xl border-2 pointer-events-none"
@@ -1151,7 +1156,7 @@ export function SpreadTable({
                         />
                       </div>
                       <div
-                        className="absolute inset-0 bg-surface-muted flex items-center justify-center"
+                        className="absolute inset-0 rounded-[inherit] overflow-hidden bg-surface-muted flex items-center justify-center"
                         style={{
                           backfaceVisibility: 'hidden',
                           WebkitBackfaceVisibility: 'hidden',
@@ -1191,7 +1196,8 @@ export function SpreadTable({
                   />
                 </div>
               ))}
-          </SlotPulseWrapper>
+            </SlotPulseWrapper>
+          </div>
         );
       })}
 

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -6,7 +6,7 @@ import { useSounds } from '../hooks/useSounds';
 import { getCardImage, FALLBACK_IMAGE } from '../lib/cardLookup';
 import { getSuitBorderColor, getRevealedCardGlow, getSuitGlowColor } from '../lib/suitColors';
 import { getSpreadTableContainerPresentation } from '../lib/spreadTablePresentation';
-import { CARD_ASPECT, getMaxCardWidth, getSpreadLayout } from '../lib/spreadLayouts';
+import { CARD_ASPECT, COMPACT_SPREAD_LAYOUTS, getMaxCardWidth, getSpreadLayout } from '../lib/spreadLayouts';
 import { extractShortLabel, getPositionLabel } from './readingBoardUtils';
 import { HandTap } from '@phosphor-icons/react';
 import { useHaptic } from '../hooks/useHaptic';
@@ -32,8 +32,7 @@ const CARD_LAYOUT_DURATION = 380;
 const CARD_LAYOUT_EXIT_DURATION = 240;
 const CARD_LAYOUT_STAGGER = 40;
 
-function getCenterOutOrder(spreadKey, totalCards) {
-  const layout = getSpreadLayout(spreadKey).positions;
+function getCenterOutOrder(layout, totalCards) {
   const count = Math.max(0, Math.min(totalCards || 0, layout.length));
   if (count <= 1) {
     return count === 1 ? [0] : [];
@@ -457,14 +456,16 @@ export function SpreadTable({
   mentionPulse = null,
   showProgress = true,
   showTactileLens = true,
-  cardsOnly = false
+  cardsOnly = false,
+  isHandset = false
 }) {
   const prefersReducedMotion = useReducedMotion();
   const { vibrate, vibrateType } = useHaptic();
   const sounds = useSounds();
   const tactileLens = useTactileLens({ disabled: !showTactileLens || compact });
   const scopeRootRef = useRef(null);
-  const layoutDefinition = getSpreadLayout(spreadKey);
+  const layoutDefinition = getSpreadLayout(spreadKey, { isHandset });
+  const usesCompactLayout = layoutDefinition === COMPACT_SPREAD_LAYOUTS[spreadKey];
   const baseLayout = layoutDefinition.positions;
   const allowOverlap = layoutDefinition.allowOverlap;
   const spreadInfo = SPREADS[spreadKey];
@@ -496,8 +497,8 @@ export function SpreadTable({
   const revealBurstIdRef = useRef(0);
   const revealBurstTimersRef = useRef([]);
   const centerOutOrder = useMemo(
-    () => getCenterOutOrder(spreadKey, limitedLayout.length),
-    [spreadKey, limitedLayout.length]
+    () => getCenterOutOrder(baseLayout, limitedLayout.length),
+    [baseLayout, limitedLayout.length]
   );
   const centerOutDelayByIndex = useMemo(() => {
     const delayMap = new Map();
@@ -690,8 +691,11 @@ export function SpreadTable({
     };
   }, [maxCardWidth]);
 
-  // Aspect ratio based on spread type
-  const aspectRatio = spreadKey === 'celtic' ? '6/5' : '3/2';
+  // Aspect ratio based on spread type. The compact handset Celtic layout stacks
+  // four card rows, so it needs a square board rather than the landscape one.
+  const aspectRatio = spreadKey === 'celtic'
+    ? (usesCompactLayout ? '1/1' : '6/5')
+    : '3/2';
   const containerPresentation = useMemo(() => getSpreadTableContainerPresentation({
     cardsOnly,
     compact,
@@ -700,9 +704,13 @@ export function SpreadTable({
 
   const sizeClass = compact
     ? 'w-11 h-[60px] xs:w-12 xs:h-16 sm:w-14 sm:h-[76px]'
-    : size === 'large'
-      ? 'w-20 h-[120px] xs:w-24 xs:h-[140px] sm:w-28 sm:h-[160px] md:w-32 md:h-[180px]'
-      : 'w-14 h-[76px] xs:w-16 xs:h-[88px] sm:w-[72px] sm:h-24 md:w-20 md:h-28';
+    : usesCompactLayout
+      // Compact handset boards are sized by the fitter, not by this class, so
+      // the class only has to stay clear of the board-derived maximum.
+      ? 'w-16 h-24 xs:w-24 xs:h-36 sm:w-32 sm:h-48'
+      : size === 'large'
+        ? 'w-20 h-[120px] xs:w-24 xs:h-[140px] sm:w-28 sm:h-[160px] md:w-32 md:h-[180px]'
+        : 'w-14 h-[76px] xs:w-16 xs:h-[88px] sm:w-[72px] sm:h-24 md:w-20 md:h-28';
 
   useEffect(() => {
     if (typeof document === 'undefined') return undefined;
@@ -1179,9 +1187,11 @@ export function SpreadTable({
         </div>
       )}
 
-      {/* Tactile Lens button - press-hold to view position meanings */}
+      {/* Tactile Lens button - press-hold to view position meanings.
+          Handset boards fill their card field edge to edge, so the button sits
+          in the reserved band below the board instead of over the cards. */}
       {!compact && showTactileLens && (
-        <div className="absolute bottom-3 left-3 z-20">
+        <div className={`absolute left-3 z-20 ${isHandset ? 'top-full mt-2' : 'bottom-3'}`}>
           <TactileLensButton
             disabled={cards.length === 0}
             isActive={tactileLens.isActive}

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -1097,7 +1097,7 @@ export function SpreadTable({
                       isRevealed={isRevealed}
                       prefersReducedMotion={prefersReducedMotion}
                       forceRevealOnMount={forceRevealOnMount}
-                      className="w-full h-full relative"
+                      className="w-full h-full relative rounded-[inherit]"
                       style={{
                         transformStyle: 'preserve-3d',
                         WebkitTransformStyle: 'preserve-3d',
@@ -1130,30 +1130,6 @@ export function SpreadTable({
                             {displayCard.name.replace(/^The /, '')}
                           </span>
                         </div>
-                        <OneShotRing
-                          active={shouldHighlightReturn}
-                          prefersReducedMotion={prefersReducedMotion}
-                          className="absolute inset-[-8%] rounded-xl border-2 border-secondary/70 pointer-events-none"
-                          duration={prefersReducedMotion ? 500 : 1100}
-                          opacityKeyframes={[0.8, 0.35, 0]}
-                          scaleKeyframes={[1, 1.03, 1.05]}
-                          reducedOpacity={0.5}
-                        />
-                        <OneShotRing
-                          key={`mention-${mentionPulseId}-${i}`}
-                          data-mention-pulse-ring
-                          active={shouldMentionPulse}
-                          prefersReducedMotion={prefersReducedMotion}
-                          className="absolute inset-[-10%] rounded-xl border-2 pointer-events-none"
-                          duration={prefersReducedMotion ? 500 : 950}
-                          opacityKeyframes={[0.75, 0.45, 0]}
-                          scaleKeyframes={[1, 1.04, 1.08]}
-                          reducedOpacity={0.55}
-                          style={{
-                            borderColor: getSuitBorderColor(displayCard),
-                            boxShadow: `0 0 18px ${getSuitGlowColor(displayCard, 0.5)}`
-                          }}
-                        />
                       </div>
                       <div
                         className="absolute inset-0 rounded-[inherit] overflow-hidden bg-surface-muted flex items-center justify-center"
@@ -1177,6 +1153,30 @@ export function SpreadTable({
                           ) : null}
                         </div>
                       </div>
+                      <OneShotRing
+                        active={shouldHighlightReturn}
+                        prefersReducedMotion={prefersReducedMotion}
+                        className="absolute inset-[-8%] rounded-xl border-2 border-secondary/70 pointer-events-none"
+                        duration={prefersReducedMotion ? 500 : 1100}
+                        opacityKeyframes={[0.8, 0.35, 0]}
+                        scaleKeyframes={[1, 1.03, 1.05]}
+                        reducedOpacity={0.5}
+                      />
+                      <OneShotRing
+                        key={`mention-${mentionPulseId}-${i}`}
+                        data-mention-pulse-ring
+                        active={shouldMentionPulse}
+                        prefersReducedMotion={prefersReducedMotion}
+                        className="absolute inset-[-10%] rounded-xl border-2 pointer-events-none"
+                        duration={prefersReducedMotion ? 500 : 950}
+                        opacityKeyframes={[0.75, 0.45, 0]}
+                        scaleKeyframes={[1, 1.04, 1.08]}
+                        reducedOpacity={0.55}
+                        style={{
+                          borderColor: getSuitBorderColor(displayCard),
+                          boxShadow: `0 0 18px ${getSuitGlowColor(displayCard, 0.5)}`
+                        }}
+                      />
                     </FlipCard>
                   </>
                 );

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -6,6 +6,7 @@ import { useSounds } from '../hooks/useSounds';
 import { getCardImage, FALLBACK_IMAGE } from '../lib/cardLookup';
 import { getSuitBorderColor, getRevealedCardGlow, getSuitGlowColor } from '../lib/suitColors';
 import { getSpreadTableContainerPresentation } from '../lib/spreadTablePresentation';
+import { CARD_ASPECT, getMaxCardWidth, getSpreadLayout } from '../lib/spreadLayouts';
 import { extractShortLabel, getPositionLabel } from './readingBoardUtils';
 import { HandTap } from '@phosphor-icons/react';
 import { useHaptic } from '../hooks/useHaptic';
@@ -17,55 +18,6 @@ import { CardBack } from './CardBack';
 import { CardInfoPopover } from './CardInfoPopover';
 import { ParticleLayer } from './ParticleLayer';
 
-/**
- * Spread layout definitions (x, y as percentage of container)
- * Each position includes coordinates and optional rotation
- */
-const SPREAD_LAYOUTS = {
-  single: [
-    { x: 50, y: 50, scale: 1.2 }
-  ],
-  threeCard: [
-    { x: 20, y: 50, label: 'Past' },
-    { x: 50, y: 50, label: 'Present' },
-    { x: 80, y: 50, label: 'Future' }
-  ],
-  fiveCard: [
-    { x: 50, y: 20, label: 'Core' },
-    { x: 20, y: 50, label: 'Challenge' },
-    { x: 50, y: 50, label: 'Hidden' },
-    { x: 80, y: 50, label: 'Support' },
-    { x: 50, y: 80, label: 'Direction' }
-  ],
-  decision: [
-    { x: 50, y: 20, label: 'Heart' },
-    { x: 25, y: 50, label: 'Path A' },
-    { x: 75, y: 50, label: 'Path B' },
-    { x: 50, y: 70, label: 'Clarity' },
-    { x: 50, y: 80, label: 'Free Will' }
-  ],
-  relationship: [
-    { x: 30, y: 50, label: 'You' },
-    { x: 70, y: 50, label: 'Them' },
-    { x: 50, y: 75, label: 'Connection' },
-    { x: 25, y: 22, label: 'Dynamics' },
-    { x: 75, y: 22, label: 'Outcome' }
-  ],
-  celtic: [
-    { x: 35, y: 50, label: 'Present' },
-    { x: 35, y: 50, label: 'Challenge', rotate: 90, offsetX: 3 },
-    { x: 15, y: 50, label: 'Past' },
-    { x: 55, y: 50, label: 'Near Future' },
-    { x: 35, y: 20, label: 'Conscious' },
-    { x: 35, y: 80, label: 'Subconscious' },
-    { x: 80, y: 80, label: 'Self/Advice' },
-    { x: 80, y: 60, label: 'External' },
-    { x: 80, y: 40, label: 'Hopes/Fears' },
-    { x: 80, y: 20, label: 'Outcome' }
-  ]
-};
-
-const CARD_ASPECT = 2 / 3;
 const CELTIC_CHALLENGE_OFFSET = {
   minPx: 18,
   maxPx: 44,
@@ -81,7 +33,7 @@ const CARD_LAYOUT_EXIT_DURATION = 240;
 const CARD_LAYOUT_STAGGER = 40;
 
 function getCenterOutOrder(spreadKey, totalCards) {
-  const layout = SPREAD_LAYOUTS[spreadKey] || SPREAD_LAYOUTS.single;
+  const layout = getSpreadLayout(spreadKey).positions;
   const count = Math.max(0, Math.min(totalCards || 0, layout.length));
   if (count <= 1) {
     return count === 1 ? [0] : [];
@@ -101,32 +53,6 @@ function getCenterOutOrder(spreadKey, totalCards) {
       return da - db;
     });
 }
-
-const getMaxCardWidth = (layout, bounds) => {
-  const width = bounds.width;
-  const height = bounds.height;
-  if (!width || !height) return null;
-  let maxWidth = Infinity;
-
-  layout.forEach((pos) => {
-    const offsetX = pos.offsetX || 0;
-    const x = ((pos.x + offsetX) / 100) * width;
-    const y = (pos.y / 100) * height;
-    const scale = pos.scale || 1;
-    const isRotated = pos.rotate && Math.abs(pos.rotate) % 180 === 90;
-    const aspect = isRotated ? 1 / CARD_ASPECT : CARD_ASPECT;
-    const xLimit = 2 * Math.min(x, width - x);
-    const yLimit = 2 * Math.min(y, height - y);
-    const widthLimit = Math.min(xLimit, yLimit * aspect) / scale;
-
-    if (widthLimit < maxWidth) {
-      maxWidth = widthLimit;
-    }
-  });
-
-  if (!Number.isFinite(maxWidth)) return null;
-  return Math.max(0, maxWidth);
-};
 
 function SlotPulseWrapper({ active, prefersReducedMotion, className, style, children, ...props }) {
   const ref = useRef(null);
@@ -538,7 +464,9 @@ export function SpreadTable({
   const sounds = useSounds();
   const tactileLens = useTactileLens({ disabled: !showTactileLens || compact });
   const scopeRootRef = useRef(null);
-  const baseLayout = SPREAD_LAYOUTS[spreadKey] || SPREAD_LAYOUTS.single;
+  const layoutDefinition = getSpreadLayout(spreadKey);
+  const baseLayout = layoutDefinition.positions;
+  const allowOverlap = layoutDefinition.allowOverlap;
   const spreadInfo = SPREADS[spreadKey];
   const maxCards = typeof spreadInfo?.maxCards === 'number' ? spreadInfo.maxCards : null;
   const drawCount = typeof spreadInfo?.drawCount === 'number'
@@ -647,8 +575,8 @@ export function SpreadTable({
 
 
   const baseMaxCardWidth = useMemo(
-    () => getMaxCardWidth(limitedLayout, tableBounds),
-    [limitedLayout, tableBounds]
+    () => getMaxCardWidth(limitedLayout, tableBounds, allowOverlap),
+    [allowOverlap, limitedLayout, tableBounds]
   );
 
   const resolvedLayout = useMemo(() => {
@@ -750,8 +678,8 @@ export function SpreadTable({
   }, [cards, visibleLayout, tableBounds.width, tableBounds.height, prefersReducedMotion, layoutStagger]);
 
   const maxCardWidth = useMemo(
-    () => getMaxCardWidth(visibleLayout, tableBounds),
-    [visibleLayout, tableBounds]
+    () => getMaxCardWidth(visibleLayout, tableBounds, allowOverlap),
+    [allowOverlap, visibleLayout, tableBounds]
   );
 
   const cardSizeStyle = useMemo(() => {
@@ -763,7 +691,7 @@ export function SpreadTable({
   }, [maxCardWidth]);
 
   // Aspect ratio based on spread type
-  const aspectRatio = spreadKey === 'celtic' ? '4/3' : '3/2';
+  const aspectRatio = spreadKey === 'celtic' ? '6/5' : '3/2';
   const containerPresentation = useMemo(() => getSpreadTableContainerPresentation({
     cardsOnly,
     compact,
@@ -1296,7 +1224,7 @@ export function SpreadTableCompact({
   onSlotClick,
   activeSlot
 }) {
-  const layout = SPREAD_LAYOUTS[spreadKey] || SPREAD_LAYOUTS.single;
+  const layout = getSpreadLayout(spreadKey).positions;
   const spreadInfo = SPREADS[spreadKey];
   const maxCards = typeof spreadInfo?.maxCards === 'number' ? spreadInfo.maxCards : null;
   const drawCount = typeof spreadInfo?.drawCount === 'number'

--- a/src/components/SpreadTable.jsx
+++ b/src/components/SpreadTable.jsx
@@ -16,7 +16,9 @@ import { TactileLensButton, TactileLensOverlay } from './TactileLensOverlay';
 import { SpreadProgressIndicator } from './SpreadProgressIndicator';
 import { CardBack } from './CardBack';
 import { CardInfoPopover } from './CardInfoPopover';
-import { ParticleLayer } from './ParticleLayer';
+import { getSlotRevealSparks } from '../lib/slotRevealBurst';
+
+const SLOT_REVEAL_SPARKS = getSlotRevealSparks();
 
 const CELTIC_CHALLENGE_OFFSET = {
   minPx: 18,
@@ -189,6 +191,32 @@ function FlashRing({ active, prefersReducedMotion, className }) {
   if (!active) return null;
 
   return <div ref={ref} className={className} />;
+}
+
+/**
+ * SlotRevealBurst - CSS spark burst played when a slot reveals.
+ * Decorative and non-interactive; one shared keyframe drives every spark, with
+ * direction and reach carried on per-spark custom properties.
+ */
+function SlotRevealBurst({ suit }) {
+  const sparkColor = getSuitGlowColor({ suit }, 0.85);
+
+  return (
+    <div className="slot-reveal-burst" data-slot-reveal-burst aria-hidden="true">
+      {SLOT_REVEAL_SPARKS.map((spark, index) => (
+        <span
+          key={index}
+          className="slot-reveal-burst__spark"
+          data-slot-reveal-spark
+          style={{
+            '--angle': `${spark.angle}deg`,
+            '--distance': `${spark.distance}px`,
+            '--spark-color': sparkColor
+          }}
+        />
+      ))}
+    </div>
+  );
 }
 
 function FlipCard({
@@ -1132,13 +1160,7 @@ export function SpreadTable({
               .map((burst) => (
                 <div key={burst.id} className="pointer-events-none absolute inset-[-22%] z-[15]">
                   <div className="slot-reveal-bloom" aria-hidden="true" />
-                  <ParticleLayer
-                    id={`slot-reveal-burst-${spreadKey}-${i}-${burst.id}`}
-                    preset="reveal-burst"
-                    suit={burst.suit || card?.suit || null}
-                    intensity={prefersReducedMotion ? 0.25 : 0.62}
-                    zIndex={1}
-                  />
+                  <SlotRevealBurst suit={burst.suit || card?.suit || null} />
                 </div>
               ))}
             </SlotPulseWrapper>

--- a/src/lib/slotRevealBurst.js
+++ b/src/lib/slotRevealBurst.js
@@ -1,0 +1,24 @@
+/**
+ * Geometry for the CSS slot reveal burst.
+ *
+ * Kept free of DOM access so the spark fan can be verified directly, and free of
+ * randomness so a reveal never renders two different bursts.
+ */
+
+export const SLOT_REVEAL_SPARK_COUNT = 10;
+
+// Cycled so neighbouring sparks reach different depths; one shared reach reads
+// as an expanding ring rather than a burst.
+const SPARK_REACH_CYCLE_PX = [44, 32, 38, 50];
+
+/**
+ * @returns {Array<{ angle: number, distance: number }>} angle in degrees,
+ * distance in px, one entry per spark, fanned evenly around the slot.
+ */
+export function getSlotRevealSparks() {
+  const step = 360 / SLOT_REVEAL_SPARK_COUNT;
+  return Array.from({ length: SLOT_REVEAL_SPARK_COUNT }, (_, index) => ({
+    angle: index * step,
+    distance: SPARK_REACH_CYCLE_PX[index % SPARK_REACH_CYCLE_PX.length]
+  }));
+}

--- a/src/lib/spreadLayouts.js
+++ b/src/lib/spreadLayouts.js
@@ -57,7 +57,36 @@ export const SPREAD_LAYOUTS = {
   }
 };
 
-export function getSpreadLayout(spreadKey) {
+/**
+ * Handset substitutions for spreads the desktop geometry cannot fit legibly on a
+ * narrow board. Position order and labels mirror `SPREAD_LAYOUTS` exactly so the
+ * numbering, roles and narrative contracts are unchanged.
+ */
+export const COMPACT_SPREAD_LAYOUTS = {
+  celtic: {
+    // Cross as a compact plus over a single horizontal staff row. Four card rows
+    // spaced a quarter of the square board apart, so the board height rather
+    // than the crossing card sets the card size.
+    positions: [
+      { x: 50, y: 37.5, label: 'Present' },
+      { x: 50, y: 37.5, label: 'Challenge', rotate: 90 },
+      { x: 22, y: 37.5, label: 'Past' },
+      { x: 78, y: 37.5, label: 'Near Future' },
+      { x: 50, y: 12.5, label: 'Conscious' },
+      { x: 50, y: 62.5, label: 'Subconscious' },
+      { x: 12.5, y: 87.5, label: 'Self/Advice' },
+      { x: 37.5, y: 87.5, label: 'External' },
+      { x: 62.5, y: 87.5, label: 'Hopes/Fears' },
+      { x: 87.5, y: 87.5, label: 'Outcome' }
+    ],
+    allowOverlap: [[0, 1]]
+  }
+};
+
+export function getSpreadLayout(spreadKey, { isHandset = false } = {}) {
+  if (isHandset && COMPACT_SPREAD_LAYOUTS[spreadKey]) {
+    return COMPACT_SPREAD_LAYOUTS[spreadKey];
+  }
   return SPREAD_LAYOUTS[spreadKey] || SPREAD_LAYOUTS.single;
 }
 

--- a/src/lib/spreadLayouts.js
+++ b/src/lib/spreadLayouts.js
@@ -1,0 +1,129 @@
+export const CARD_ASPECT = 2 / 3;
+
+export const SPREAD_LAYOUTS = {
+  single: {
+    positions: [
+      { x: 50, y: 50, scale: 1.2 }
+    ]
+  },
+  threeCard: {
+    positions: [
+      { x: 20, y: 50, label: 'Past' },
+      { x: 50, y: 50, label: 'Present' },
+      { x: 80, y: 50, label: 'Future' }
+    ]
+  },
+  fiveCard: {
+    positions: [
+      { x: 50, y: 20, label: 'Core' },
+      { x: 20, y: 50, label: 'Challenge' },
+      { x: 50, y: 50, label: 'Hidden' },
+      { x: 80, y: 50, label: 'Support' },
+      { x: 50, y: 80, label: 'Direction' }
+    ]
+  },
+  decision: {
+    positions: [
+      { x: 50, y: 22, label: 'Heart' },
+      { x: 20, y: 50, label: 'Path A' },
+      { x: 80, y: 50, label: 'Path B' },
+      { x: 40, y: 78, label: 'Clarity' },
+      { x: 60, y: 78, label: 'Free Will' }
+    ]
+  },
+  relationship: {
+    positions: [
+      { x: 30, y: 50, label: 'You' },
+      { x: 70, y: 50, label: 'Them' },
+      { x: 50, y: 75, label: 'Connection' },
+      { x: 25, y: 22, label: 'Dynamics' },
+      { x: 75, y: 22, label: 'Outcome' }
+    ]
+  },
+  celtic: {
+    positions: [
+      { x: 35, y: 50, label: 'Present' },
+      { x: 35, y: 50, label: 'Challenge', rotate: 90, offsetX: 3 },
+      { x: 12, y: 50, label: 'Past' },
+      { x: 58, y: 50, label: 'Near Future' },
+      { x: 35, y: 12, label: 'Conscious' },
+      { x: 35, y: 88, label: 'Subconscious' },
+      { x: 82, y: 88, label: 'Self/Advice' },
+      { x: 82, y: 62.67, label: 'External' },
+      { x: 82, y: 37.33, label: 'Hopes/Fears' },
+      { x: 82, y: 12, label: 'Outcome' }
+    ],
+    allowOverlap: [[0, 1]]
+  }
+};
+
+export function getSpreadLayout(spreadKey) {
+  return SPREAD_LAYOUTS[spreadKey] || SPREAD_LAYOUTS.single;
+}
+
+const toFiniteNumber = (value, fallback) => (
+  Number.isFinite(value) ? value : fallback
+);
+
+const getPositionGeometry = (position, bounds) => {
+  const scale = Number.isFinite(position?.scale) && position.scale > 0
+    ? position.scale
+    : 1;
+  const rotation = toFiniteNumber(position?.rotate, 0) * (Math.PI / 180);
+  const cos = Math.abs(Math.cos(rotation));
+  const sin = Math.abs(Math.sin(rotation));
+  const xPercent = toFiniteNumber(position?.x, 50) + toFiniteNumber(position?.offsetX, 0);
+  const yPercent = toFiniteNumber(position?.y, 50) + toFiniteNumber(position?.offsetY, 0);
+
+  return {
+    x: (xPercent / 100) * bounds.width,
+    y: (yPercent / 100) * bounds.height,
+    // Width is relative to card width; height is relative to card height.
+    effectiveWidth: scale * (cos + (sin / CARD_ASPECT)),
+    effectiveHeight: scale * (cos + (sin * CARD_ASPECT))
+  };
+};
+
+const hasAllowedOverlap = (allowOverlap, leftIndex, rightIndex) => (
+  allowOverlap.some((pair) => (
+    Array.isArray(pair) &&
+    ((pair[0] === leftIndex && pair[1] === rightIndex) ||
+      (pair[0] === rightIndex && pair[1] === leftIndex))
+  ))
+);
+
+export function getMaxCardWidth(layout, bounds, allowOverlap = []) {
+  const width = bounds?.width;
+  const height = bounds?.height;
+  if (!Array.isArray(layout) || layout.length === 0) return null;
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+
+  const positions = layout.map((position) => getPositionGeometry(position, { width, height }));
+  let maxWidth = Infinity;
+
+  positions.forEach((position) => {
+    const xEdge = Math.max(0, Math.min(position.x, width - position.x));
+    const yEdge = Math.max(0, Math.min(position.y, height - position.y));
+    const horizontalLimit = (2 * xEdge) / position.effectiveWidth;
+    const verticalLimit = ((2 * yEdge) / position.effectiveHeight) * CARD_ASPECT;
+    maxWidth = Math.min(maxWidth, horizontalLimit, verticalLimit);
+  });
+
+  for (let leftIndex = 0; leftIndex < positions.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < positions.length; rightIndex += 1) {
+      if (hasAllowedOverlap(allowOverlap, leftIndex, rightIndex)) continue;
+
+      const left = positions[leftIndex];
+      const right = positions[rightIndex];
+      const separationX = Math.abs(left.x - right.x);
+      const separationY = Math.abs(left.y - right.y);
+      const horizontalLimit = (2 * separationX) / (left.effectiveWidth + right.effectiveWidth);
+      const verticalLimit = (
+        (2 * separationY) / (left.effectiveHeight + right.effectiveHeight)
+      ) * CARD_ASPECT;
+      maxWidth = Math.min(maxWidth, Math.max(horizontalLimit, verticalLimit));
+    }
+  }
+
+  return Number.isFinite(maxWidth) ? Math.max(0, maxWidth) : null;
+}

--- a/src/styles/tarot.css
+++ b/src/styles/tarot.css
@@ -233,6 +233,14 @@
   --glass-border: rgba(232, 218, 195, 0.22);
 }
 
+[data-layout-card] {
+  scale: var(--layout-card-scale, 1);
+}
+
+[data-layout-card]:active:not(:disabled) {
+  scale: calc(var(--layout-card-scale, 1) * 0.95);
+}
+
 .glass-panel {
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);

--- a/src/styles/tarot.css
+++ b/src/styles/tarot.css
@@ -3002,6 +3002,43 @@ input[type="range"]:focus::-webkit-slider-thumb {
   animation: slotRevealBloom 0.8s ease-out forwards;
 }
 
+/* Reveal burst: one shared keyframe drives every spark; direction and reach
+   come from per-spark --angle / --distance. Transform and opacity only, so the
+   sparks composite on the GPU and the global reduced-motion block collapses
+   them for free. */
+@keyframes slotRevealSpark {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--angle)) translateX(0) scale(0.35);
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(var(--angle)) translateX(var(--distance)) scale(1);
+  }
+}
+
+.slot-reveal-burst {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.slot-reveal-burst__spark {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 5px;
+  height: 5px;
+  margin: -2.5px 0 0 -2.5px;
+  border-radius: 999px;
+  background: var(--spark-color);
+  box-shadow: 0 0 6px var(--spark-color);
+  animation: slotRevealSpark 0.72s ease-out forwards;
+}
+
 @supports (color: color-mix(in srgb, red 50%, blue)) {
   @keyframes placeholderPulse {
     0%,

--- a/tests/slotRevealBurst.test.mjs
+++ b/tests/slotRevealBurst.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  SLOT_REVEAL_SPARK_COUNT,
+  getSlotRevealSparks
+} from '../src/lib/slotRevealBurst.js';
+
+describe('getSlotRevealSparks', () => {
+  test('emits a small fixed number of sparks', () => {
+    assert.ok(
+      SLOT_REVEAL_SPARK_COUNT >= 6 && SLOT_REVEAL_SPARK_COUNT <= 16,
+      `expected a small fixed spark count, got ${SLOT_REVEAL_SPARK_COUNT}`
+    );
+    assert.equal(getSlotRevealSparks().length, SLOT_REVEAL_SPARK_COUNT);
+  });
+
+  test('fans the sparks evenly around the full circle', () => {
+    const sparks = getSlotRevealSparks();
+    const step = 360 / SLOT_REVEAL_SPARK_COUNT;
+
+    assert.deepEqual(
+      sparks.map((spark) => spark.angle),
+      Array.from({ length: SLOT_REVEAL_SPARK_COUNT }, (_, index) => index * step)
+    );
+  });
+
+  test('throws every spark outward at a varied reach', () => {
+    const distances = getSlotRevealSparks().map((spark) => spark.distance);
+
+    distances.forEach((distance, index) => {
+      assert.ok(distance > 0, `spark ${index} must travel outward, got ${distance}`);
+    });
+    assert.ok(
+      new Set(distances).size > 1,
+      'sparks must not all share one reach, or the burst reads as a ring'
+    );
+  });
+
+  test('is deterministic so a reveal never renders two different bursts', () => {
+    assert.deepEqual(getSlotRevealSparks(), getSlotRevealSparks());
+  });
+});

--- a/tests/spreadLayouts.test.mjs
+++ b/tests/spreadLayouts.test.mjs
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   CARD_ASPECT,
+  COMPACT_SPREAD_LAYOUTS,
   SPREAD_LAYOUTS,
-  getMaxCardWidth
+  getMaxCardWidth,
+  getSpreadLayout
 } from '../src/lib/spreadLayouts.js';
 
 const assertCloseTo = (actual, expected, tolerance = 0.0001) => {
@@ -114,4 +116,91 @@ test('declares only the Celtic crossing pair as intentionally overlapping', () =
       .flatMap(([, layout]) => layout.allowOverlap || []),
     []
   );
+});
+
+describe('handset Celtic layout', () => {
+  // The handset spread board is square; 334px is the measured board width at a
+  // 390px viewport.
+  const HANDSET_BOUNDS = { width: 334, height: 334 };
+  const DESKTOP_CELTIC_HANDSET_BOUNDS = { width: 334, height: 334 / 1.2 };
+
+  test('substitutes the compact layout only for Celtic on a handset', () => {
+    assert.equal(getSpreadLayout('celtic'), SPREAD_LAYOUTS.celtic);
+    assert.equal(getSpreadLayout('celtic', { isHandset: false }), SPREAD_LAYOUTS.celtic);
+    assert.equal(getSpreadLayout('celtic', { isHandset: true }), COMPACT_SPREAD_LAYOUTS.celtic);
+    assert.equal(getSpreadLayout('fiveCard', { isHandset: true }), SPREAD_LAYOUTS.fiveCard);
+    assert.equal(getSpreadLayout('single', { isHandset: true }), SPREAD_LAYOUTS.single);
+  });
+
+  test('keeps Celtic position order and the single crossing overlap', () => {
+    assert.deepEqual(
+      COMPACT_SPREAD_LAYOUTS.celtic.positions.map((position) => position.label),
+      SPREAD_LAYOUTS.celtic.positions.map((position) => position.label)
+    );
+    assert.deepEqual(COMPACT_SPREAD_LAYOUTS.celtic.allowOverlap, [[0, 1]]);
+  });
+
+  test('arranges the cross as a plus with the crossing card quarter-turned', () => {
+    const [present, challenge, past, nearFuture, conscious, subconscious] =
+      COMPACT_SPREAD_LAYOUTS.celtic.positions;
+
+    assert.equal(challenge.x, present.x);
+    assert.equal(conscious.x, present.x);
+    assert.equal(subconscious.x, present.x);
+    assert.ok(past.x < present.x, 'Past sits left of Present');
+    assert.ok(nearFuture.x > present.x, 'Near Future sits right of Present');
+
+    assert.equal(challenge.y, present.y);
+    assert.equal(past.y, present.y);
+    assert.equal(nearFuture.y, present.y);
+    assert.ok(conscious.y < present.y, 'Conscious sits above Present');
+    assert.ok(subconscious.y > present.y, 'Subconscious sits below Present');
+
+    assert.equal(challenge.rotate, 90);
+  });
+
+  test('lays the staff out as one horizontal row beneath the cross', () => {
+    const positions = COMPACT_SPREAD_LAYOUTS.celtic.positions;
+    const cross = positions.slice(0, 6);
+    const staff = positions.slice(6);
+
+    assert.equal(staff.length, 4);
+    assert.deepEqual([...new Set(staff.map((position) => position.y))], [staff[0].y]);
+    assert.ok(
+      staff[0].y > Math.max(...cross.map((position) => position.y)),
+      'the staff row sits below every cross position'
+    );
+    assert.deepEqual(
+      staff.map((position) => position.x),
+      [...staff.map((position) => position.x)].sort((left, right) => left - right)
+    );
+  });
+
+  test('fits a card a sixth of the square handset board without unintended overlap', () => {
+    const width = getMaxCardWidth(
+      COMPACT_SPREAD_LAYOUTS.celtic.positions,
+      HANDSET_BOUNDS,
+      COMPACT_SPREAD_LAYOUTS.celtic.allowOverlap
+    );
+
+    assertCloseTo(width, HANDSET_BOUNDS.height / 6, 0.001);
+  });
+
+  test('fits a materially larger card than the desktop Celtic layout does on a handset', () => {
+    const compactWidth = getMaxCardWidth(
+      COMPACT_SPREAD_LAYOUTS.celtic.positions,
+      HANDSET_BOUNDS,
+      COMPACT_SPREAD_LAYOUTS.celtic.allowOverlap
+    );
+    const desktopWidth = getMaxCardWidth(
+      SPREAD_LAYOUTS.celtic.positions,
+      DESKTOP_CELTIC_HANDSET_BOUNDS,
+      SPREAD_LAYOUTS.celtic.allowOverlap
+    );
+
+    assert.ok(
+      compactWidth >= desktopWidth * 1.2,
+      `expected compact width ${compactWidth} to be at least 20% above desktop width ${desktopWidth}`
+    );
+  });
 });

--- a/tests/spreadLayouts.test.mjs
+++ b/tests/spreadLayouts.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  CARD_ASPECT,
+  SPREAD_LAYOUTS,
+  getMaxCardWidth
+} from '../src/lib/spreadLayouts.js';
+
+const assertCloseTo = (actual, expected, tolerance = 0.0001) => {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`
+  );
+};
+
+describe('getMaxCardWidth', () => {
+  test('uses the nearest horizontal or vertical board edge', () => {
+    const width = getMaxCardWidth(
+      [{ x: 50, y: 50 }],
+      { width: 300, height: 200 }
+    );
+
+    assertCloseTo(width, 133.333333);
+  });
+
+  test('includes position offsets in edge constraints', () => {
+    const width = getMaxCardWidth(
+      [{ x: 10, y: 50, offsetX: 5 }],
+      { width: 200, height: 200 }
+    );
+
+    assertCloseTo(width, 60);
+  });
+
+  test('separates a horizontally adjacent pair', () => {
+    const width = getMaxCardWidth(
+      [{ x: 40, y: 50 }, { x: 60, y: 50 }],
+      { width: 300, height: 300 }
+    );
+
+    assertCloseTo(width, 60);
+  });
+
+  test('uses the separating axis that permits the larger non-overlapping card', () => {
+    const width = getMaxCardWidth(
+      [{ x: 45, y: 40 }, { x: 55, y: 60 }],
+      { width: 300, height: 300 }
+    );
+
+    assertCloseTo(width, 40);
+  });
+
+  test('does not constrain an explicitly allowed overlapping pair', () => {
+    const width = getMaxCardWidth(
+      [{ x: 50, y: 50 }, { x: 50, y: 50 }],
+      { width: 300, height: 200 },
+      [[0, 1]]
+    );
+
+    assertCloseTo(width, 133.333333);
+  });
+
+  test('constrains the same coincident pair when it is not allow-listed', () => {
+    const width = getMaxCardWidth(
+      [{ x: 50, y: 50 }, { x: 50, y: 50 }],
+      { width: 300, height: 200 }
+    );
+
+    assert.equal(width, 0);
+  });
+
+  test('folds a quarter-turn into horizontal card extent', () => {
+    const width = getMaxCardWidth(
+      [{ x: 45, y: 50, rotate: 90 }, { x: 55, y: 50 }],
+      { width: 1000, height: 1000 }
+    );
+
+    assertCloseTo(width, 80);
+  });
+
+  test('folds scale into pair separation', () => {
+    const width = getMaxCardWidth(
+      [{ x: 35, y: 50, scale: 2 }, { x: 65, y: 50 }],
+      { width: 500, height: 500 }
+    );
+
+    assertCloseTo(width, 100);
+  });
+
+  test('returns null for empty layouts and unusable bounds', () => {
+    assert.equal(getMaxCardWidth([], { width: 300, height: 200 }), null);
+    assert.equal(getMaxCardWidth([{ x: 50, y: 50 }], { width: 0, height: 200 }), null);
+  });
+
+  test('clamps out-of-bounds positions without returning a negative dimension', () => {
+    const width = getMaxCardWidth(
+      [{ x: 150, y: 50, scale: -2, rotate: Number.NaN }],
+      { width: 300, height: 200 }
+    );
+
+    assert.equal(width, 0);
+  });
+});
+
+test('exports the card aspect used by spread geometry', () => {
+  assert.equal(CARD_ASPECT, 2 / 3);
+});
+
+test('declares only the Celtic crossing pair as intentionally overlapping', () => {
+  assert.deepEqual(SPREAD_LAYOUTS.celtic.allowOverlap, [[0, 1]]);
+  assert.deepEqual(
+    Object.entries(SPREAD_LAYOUTS)
+      .filter(([key]) => key !== 'celtic')
+      .flatMap(([, layout]) => layout.allowOverlap || []),
+    []
+  );
+});


### PR DESCRIPTION
Implements workstreams 1-5 of `docs/reviews/2026-card-reveal-remediation-plan.md`. Workstreams 6 (audio) and 7 (dead-code removal) are **not** in this branch.

## What changed

**1 · Positioning and clipping** (`fc8b462`, `0ffff81`)
Stabilised spread card positioning and stopped narrative mention pulses being clipped at the card border.

**2 · Reversed-card presentation** (`31f8c70`, `3daf205`)
Reversed cards now read as reversed in every live representation — accessible name, visible label, and the compact strip — with the card image inverted while its name overlay stays upright.

**3 · Shared overlap-aware layout geometry** (`0ea2687`)
Extracted all layouts to `src/lib/spreadLayouts.js` with a testable fitter. Cards now shrink rather than collide; Celtic positions 0/1 are the only intentional overlap in the whole deck of spreads. Decision and Celtic coordinates retuned against the automated check rather than by eye.

**4 · Handset Celtic Cross** (`133ad3a`)
At 390px the desktop Celtic geometry fits only a 44.5px card. Added `COMPACT_SPREAD_LAYOUTS.celtic` — the cross as a plus over a single horizontal staff row on a square board — selected through the existing `isHandset` signal. Position indices, labels and roles are unchanged. The board fitter rather than a fixed size class now owns card size across the handset range, the Tactile Lens button moved out of the card field, and a reserved band below the board keeps cards off the Reset control. The Celtic map and Tactile Lens overlays read the layout actually on screen instead of the desktop constant.

**5 · Reveal effects and performance** (`0ed85b8`)
Each revealed slot mounted its own tsParticles canvas, so a Celtic reveal-all spun up nine engines and tore them down again — and the preset's directionless random movement read as haze rather than a burst. Replaced with ten CSS spark spans driven by one shared keyframe, animating transform and opacity only. Tinting still flows through `getSuitGlowColor`; the existing global reduced-motion block collapses the effect for free. The dead `reveal-burst` particle preset had no other caller and is removed.

## Measured results

| Viewport | Spread | Before | After |
|---|---|---:|---:|
| 390x844 | Celtic card width | 44.47px | 55.66px |
| 600x900 | Celtic card width | 64px (size-class capped) | 90.66px |
| 1280x900 | Celtic reveal-all canvases | 9 | 0 |

768x1024 and 1280x900 layout expectations are unchanged, proving the desktop/tablet geometry is untouched.

## Verification

Run at the exact tip commit:

- `npm test` — 1,595 passed, 0 failed (391 suites)
- Serial layout E2E (`e2e/spread-layout.spec.js`) — 11 passed, 0 failed
- `npm run gate:design` — passed; raw `rgba()` literal count unchanged
- `npm run test:a11y` — 0 errors
- `npm run build` — passed
- `npx eslint` over all changed files — clean

## Known issues, not fixed here

- **Handset boundary divergence.** `SpreadLayoutFixture` derives `isHandset` from `window.innerWidth < 640`, while production uses `useHandsetLayout` (`max-width: 768px`). At 640-768px the harness exercises a path production never takes — for Celtic layout selection *and* for the pre-existing `tableSize` choice, which is why the 768px floors read 127/99/92 rather than production's 80px cap. This predates workstream 4 and affects all spreads, so it was left alone rather than rewrite previously reviewed coverage. New 600x900 coverage exercises the compact layout's wide end within the fixture's own convention.
- **Reduced motion is not reaching the browser** under the worktree's local Playwright config: an in-page probe showed `matchMedia('(prefers-reduced-motion: reduce)').matches === false` even with a `test.use` override, though runtime `page.emulateMedia` works. Workstreams 1-4 were therefore verified with animations live, which is the stricter condition for layout assertions. The burst tests now set motion explicitly rather than trusting the runner.
- Spread-selector illustrations are cosmetically stale against the retuned coordinates, as the approved plan accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared spread layout geometry with an overlap-aware card fitter, add a compact handset Celtic Cross layout, and replace the slot reveal particle burst with a CSS-based spark effect while improving reversed-card presentation and accessibility.

New Features:
- Add a compact handset Celtic Cross layout that preserves Celtic position order while fitting larger cards on narrow viewports.
- Expose a development-only spread layout fixture route for visually and programmatically exercising spread geometry and reveal behaviour.

Bug Fixes:
- Prevent narrative mention pulses from being clipped at the card border on revealed cards.
- Ensure Celtic Cross orientation overlays read and follow the actual layout on screen instead of a desktop-only constant.

Enhancements:
- Centralize spread layout definitions and card sizing logic in a dedicated spreadLayouts module with explicit overlap metadata.
- Retune spread card positioning so cards stay centred, avoid unintended overlap, and keep pulses and overlays visible beyond card borders.
- Refine reversed-card presentation so the image inverts while text labels remain upright, with reversal surfaced consistently in accessible names and labels across main and compact views.
- Adjust handset reading board padding and Tactile Lens button placement so controls stay clear of the card field and align with the active layout coordinates.
- Update CardInfoPopover labelling and badge styling to better reflect upright vs reversed state.

Tests:
- Add Node tests for spread layout geometry and max card width calculations, including handset Celtic behaviour and intentional overlap handling.
- Add Playwright E2E coverage for spread layouts across key viewports, handset Celtic control clearance, compact Celtic sizing, reveal burst behaviour (normal and reduced motion), mention pulse visibility, and reversed-card representations.
- Add unit tests for slot reveal burst spark fan geometry to keep the burst deterministic and visually coherent.

Chores:
- Remove the unused tsParticles reveal-burst preset now that slot reveal effects are driven by CSS sparks instead of per-slot canvases.